### PR TITLE
Partial v2 revert

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,10 +4,10 @@ SHELL := /bin/bash
 
 GO111MODULE := on
 
-GOPKG := github.com/veraison/corim/v2/corim
-GOPKG += github.com/veraison/corim/v2/comid
-GOPKG += github.com/veraison/corim/v2/cots
-GOPKG += github.com/veraison/corim/v2/cocli/cmd
+GOPKG := github.com/veraison/corim/corim
+GOPKG += github.com/veraison/corim/comid
+GOPKG += github.com/veraison/corim/cots
+GOPKG += github.com/veraison/corim/cocli/cmd
 
 MOCKGEN := $(shell go env GOPATH)/bin/mockgen
 INTERFACES := cocli/cmd/isubmitter.go

--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 [![linters](https://github.com/veraison/corim/actions/workflows/linters.yml/badge.svg)](https://github.com/veraison/corim/actions/workflows/linters.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/veraison/corim.svg)](https://pkg.go.dev/github.com/veraison/corim)
 
-The [`corim/v2/corim`](corim) and [`corim/v2/comid`](comid) packages provide a golang API for low-level manipulation of [Concise Reference Integrity Manifest (CoRIM)](https://datatracker.ietf.org/doc/draft-ietf-rats-corim/) and Concise Module Identifier (CoMID) tags respectively.
+The [`corim/corim`](corim) and [`corim/comid`](comid) packages provide a golang API for low-level manipulation of [Concise Reference Integrity Manifest (CoRIM)](https://datatracker.ietf.org/doc/draft-birkholz-rats-corim/) and Concise Module Identifier (CoMID) tags respectively.
 
 > [!NOTE]
 > These API are still in active development (as is the underlying CoRIM spec).
 > They are **subject to change** in the future.
 
-The [`corim/v2/cocli`](cocli) package uses the API above (as well as the API from [`veraison/swid`](https://github.com/veraison/swid) package) to provide a user friendly command line interface for working with CoRIM, CoMID, CoSWID and CoTS.  Specifically it allows creating, signing, verifying, displaying, uploading, and more.  See [`cocli/README.md`](cocli/README.md) for further details.
+The [`corim/cocli`](cocli) package uses the API above (as well as the API from [`veraison/swid`](https://github.com/veraison/swid) package) to provide a user friendly command line interface for working with CoRIM, CoMID, CoSWID and CoTS.  Specifically it allows creating, signing, verifying, displaying, uploading, and more.  See [`cocli/README.md`](cocli/README.md) for further details.
 
 ## Developer tips
 

--- a/cocli/cmd/comidCreate.go
+++ b/cocli/cmd/comidCreate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 var (

--- a/cocli/cmd/comidCreate_test.go
+++ b/cocli/cmd/comidCreate_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 func Test_ComidCreateCmd_unknown_argument(t *testing.T) {

--- a/cocli/cmd/comidValidate.go
+++ b/cocli/cmd/comidValidate.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 var (

--- a/cocli/cmd/common.go
+++ b/cocli/cmd/common.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/spf13/afero"
-	"github.com/veraison/corim/v2/comid"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/comid"
+	"github.com/veraison/corim/cots"
 	"github.com/veraison/swid"
 )
 

--- a/cocli/cmd/corimCreate.go
+++ b/cocli/cmd/corimCreate.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/comid"
-	"github.com/veraison/corim/v2/corim"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/comid"
+	"github.com/veraison/corim/corim"
+	"github.com/veraison/corim/cots"
 	"github.com/veraison/swid"
 )
 

--- a/cocli/cmd/corimDisplay.go
+++ b/cocli/cmd/corimDisplay.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/corim"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/corim"
+	"github.com/veraison/corim/cots"
 )
 
 var (

--- a/cocli/cmd/corimExtract.go
+++ b/cocli/cmd/corimExtract.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/corim"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/corim"
+	"github.com/veraison/corim/cots"
 )
 
 var (

--- a/cocli/cmd/corimSign.go
+++ b/cocli/cmd/corimSign.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/corim"
+	"github.com/veraison/corim/corim"
 	cose "github.com/veraison/go-cose"
 )
 

--- a/cocli/cmd/corimSubmit_test.go
+++ b/cocli/cmd/corimSubmit_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	mock_deps "github.com/veraison/corim/v2/cocli/cmd/mocks"
+	mock_deps "github.com/veraison/corim/cocli/cmd/mocks"
 )
 
 func Test_CorimSubmitCmd_bad_server_url(t *testing.T) {

--- a/cocli/cmd/corimVerify.go
+++ b/cocli/cmd/corimVerify.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/corim"
+	"github.com/veraison/corim/corim"
 )
 
 var (

--- a/cocli/cmd/cotsCreate.go
+++ b/cocli/cmd/cotsCreate.go
@@ -11,7 +11,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/spf13/afero"
 	"github.com/spf13/cobra"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/cots"
 )
 
 var (

--- a/cocli/cmd/test_vars.go
+++ b/cocli/cmd/test_vars.go
@@ -3,7 +3,7 @@
 
 package cmd
 
-import "github.com/veraison/corim/v2/comid"
+import "github.com/veraison/corim/comid"
 
 var (
 	minimalCorimTemplate = []byte(`{

--- a/cocli/main.go
+++ b/cocli/main.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"github.com/veraison/corim/v2/cocli/cmd"
+	"github.com/veraison/corim/cocli/cmd"
 )
 
 func main() {

--- a/corim/cbor.go
+++ b/corim/cbor.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	cbor "github.com/fxamacker/cbor/v2"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 var (

--- a/corim/entity.go
+++ b/corim/entity.go
@@ -6,7 +6,7 @@ package corim
 import (
 	"fmt"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 // Entity stores an entity-map capable of CBOR and JSON serializations.

--- a/corim/entity_test.go
+++ b/corim/entity_test.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 func TestEntity_Valid_uninitialized(t *testing.T) {

--- a/corim/meta.go
+++ b/corim/meta.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 type Signer struct {

--- a/corim/meta_test.go
+++ b/corim/meta_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 var (

--- a/corim/signedcorim.go
+++ b/corim/signedcorim.go
@@ -45,7 +45,7 @@ func (o *SignedCorim) processHdrs() error {
 
 	// TODO(tho) key id is apparently mandatory, which doesn't look right.
 	// TODO(tho) Check with the CoRIM design team.
-	// See https://github.com/veraison/corim/v2/issues/14
+	// See https://github.com/veraison/corim/issues/14
 
 	v, ok = hdr.Protected[HeaderLabelCorimMeta]
 	if !ok {

--- a/corim/unsignedcorim.go
+++ b/corim/unsignedcorim.go
@@ -9,9 +9,9 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/cots"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 	"github.com/veraison/eat"
 	"github.com/veraison/swid"
 )

--- a/corim/unsignedcorim_test.go
+++ b/corim/unsignedcorim_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/veraison/corim/v2/comid"
-	"github.com/veraison/corim/v2/cots"
+	"github.com/veraison/corim/comid"
+	"github.com/veraison/corim/cots"
 	"github.com/veraison/swid"
 )
 

--- a/cots/cbor.go
+++ b/cots/cbor.go
@@ -7,7 +7,7 @@ import (
 	"reflect"
 
 	cbor "github.com/fxamacker/cbor/v2"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 var (

--- a/cots/cots.go
+++ b/cots/cots.go
@@ -8,7 +8,7 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 	"github.com/veraison/swid"
 )
 

--- a/cots/cots_test.go
+++ b/cots/cots_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 func TestConciseTaStore_Valid_no_environment_groups(t *testing.T) {

--- a/cots/env_group.go
+++ b/cots/env_group.go
@@ -7,7 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 )
 
 // EnvironmentGroup is the top-level representation of the unsigned-corim-map with

--- a/cots/env_group_test.go
+++ b/cots/env_group_test.go
@@ -6,7 +6,7 @@ package cots
 import (
 	"testing"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 	"github.com/veraison/swid"
 
 	"github.com/stretchr/testify/assert"

--- a/cots/example_test.go
+++ b/cots/example_test.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/veraison/corim/v2/comid"
+	"github.com/veraison/corim/comid"
 	"github.com/veraison/swid"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/veraison/corim/v2
+module github.com/veraison/corim
 
 go 1.18
 


### PR DESCRIPTION
Reverting module /v2 module name change. The reason is that go build system does not allow specifying a post-v1 module name unless there is a corresponding published release. Since we're not planning on publishing v2.0.0 until CoRIM spec is out of draft, we cannot rename the module until then. So for now, v2 development needs to happen on top of a v1 module name.