### PR TITLE
Add Integrity registers

### DIFF
--- a/comid/cbor.go
+++ b/comid/cbor.go
@@ -57,6 +57,7 @@ func comidTags() cbor.TagSet {
 
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
+		Sort:        cbor.SortCoreDeterministic,
 		IndefLength: cbor.IndefLengthForbidden,
 		TimeTag:     cbor.EncTagRequired,
 	}

--- a/comid/integrityregisters.go
+++ b/comid/integrityregisters.go
@@ -1,0 +1,138 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+package comid
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/veraison/swid"
+)
+
+const TextType = "text"
+
+// IRegisterIndex is the interface to hold register index
+// Supported index types are uint and text
+type IRegisterIndex interface{}
+
+// IntegrityRegisters holds the Integrity Registers
+type IntegrityRegisters struct {
+	m map[IRegisterIndex]Digests
+}
+
+func NewIntegrityRegisters() *IntegrityRegisters {
+	return &IntegrityRegisters{m: make(map[IRegisterIndex]Digests)}
+}
+
+// AddDigests allows inserting an array of digests at a specific index
+// Supported index types are uint and text
+func (i *IntegrityRegisters) AddDigests(index IRegisterIndex, digests Digests) error {
+	if len(digests) == 0 {
+		return fmt.Errorf("no digests to add")
+	}
+	for _, digest := range digests {
+		if err := i.AddDigest(index, digest); err != nil {
+			return fmt.Errorf("unable to add Digest: %w", err)
+		}
+	}
+	return nil
+}
+
+// AddDigest allows inserting a digest at a specific index
+// Supported index types are uint and text
+func (i *IntegrityRegisters) AddDigest(index IRegisterIndex, digest swid.HashEntry) error {
+	if i.m == nil {
+		return fmt.Errorf("no register to add digest")
+	}
+	switch t := index.(type) {
+	case string, uint, uint64:
+		i.m[t] = append(i.m[t], digest)
+	default:
+		return fmt.Errorf("unexpected type for index: %T", t)
+	}
+	return nil
+}
+
+func (i IntegrityRegisters) MarshalCBOR() ([]byte, error) {
+	return em.Marshal(i.m)
+}
+
+func (i *IntegrityRegisters) UnmarshalCBOR(data []byte) error {
+	return dm.Unmarshal(data, &i.m)
+}
+
+type keyTypeandVal struct {
+	KeyType string `json:"key_type"`
+	Value   json.RawMessage
+}
+
+func (i IntegrityRegisters) MarshalJSON() ([]byte, error) {
+	jmap := make(map[string]json.RawMessage)
+	var newkey string
+	for key, val := range i.m {
+		var ktv keyTypeandVal
+		switch t := key.(type) {
+		case uint, uint64:
+			ktv.KeyType = UintType
+			newkey = fmt.Sprintf("%v", key)
+		case string:
+			ktv.KeyType = TextType
+			newkey = key.(string)
+		default:
+			return nil, fmt.Errorf("unknown type %T for index-type-choice", t)
+		}
+
+		newval, err := json.Marshal(val)
+		if err != nil {
+			return nil, err
+		}
+		ktv.Value = newval
+		Value, err := json.Marshal(ktv)
+		if err != nil {
+			return nil, err
+		}
+		jmap[newkey] = Value
+	}
+	return json.Marshal(jmap)
+}
+
+func (i *IntegrityRegisters) UnmarshalJSON(data []byte) error {
+	if i.m == nil {
+		i.m = make(map[IRegisterIndex]Digests)
+	}
+	jmap := make(map[string]json.RawMessage)
+	var index IRegisterIndex
+	if err := json.Unmarshal(data, &jmap); err != nil {
+		return fmt.Errorf("register map decoding failure: %w", err)
+	}
+	for key, val := range jmap {
+		var ktv keyTypeandVal
+		var d Digests
+
+		if err := json.Unmarshal(val, &ktv); err != nil {
+			return fmt.Errorf("unable to unmarshal keyTypeAndValue: %w", err)
+		}
+		if err := json.Unmarshal(ktv.Value, &d); err != nil {
+			return fmt.Errorf("unable to unmarshal Digests: %w", err)
+		}
+		switch ktv.KeyType {
+		case UintType:
+			u, err := strconv.Atoi(key)
+			if err != nil {
+				return fmt.Errorf("unable to convert key to uint: %w", err)
+			} else if u < 0 {
+				return fmt.Errorf("invalid negative integer key")
+			}
+			index = uint(u)
+		case TextType:
+			index = key
+		default:
+			return fmt.Errorf("unexpected key type for index: %s", ktv.KeyType)
+		}
+		if err := i.AddDigests(index, d); err != nil {
+			return fmt.Errorf("unable to add digests into register set: %w", err)
+		}
+	}
+	return nil
+}

--- a/comid/integrityregisters_test.go
+++ b/comid/integrityregisters_test.go
@@ -1,0 +1,302 @@
+// Copyright 2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package comid
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/swid"
+)
+
+func prepareRegister(t *testing.T, iType string) (*IntegrityRegisters, error) {
+	var err error
+	val := MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")
+	entry := swid.HashEntry{HashAlgID: swid.Sha256, HashValue: val}
+	reg := NewIntegrityRegisters()
+	for index := 0; index < 5; index++ {
+		switch iType {
+		case "uint":
+			err = reg.AddDigest(uint(index), entry)
+			require.NoError(t, err)
+		case "text":
+			i := fmt.Sprint(index)
+			err = reg.AddDigest(i, entry)
+			require.NoError(t, err)
+		default:
+			err = fmt.Errorf("invalid iType = %s", iType)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+	return reg, nil
+}
+
+func TestIntegrityRegisters_AddDigest_OK(t *testing.T) {
+	_, err := prepareRegister(t, "uint")
+	require.NoError(t, err)
+}
+
+func TestIntegrityRegisters_AddDigest_NOK(t *testing.T) {
+	expectedErr := `no register to add digest`
+	register := IntegrityRegisters{}
+	err := register.AddDigest(uint(0), swid.HashEntry{})
+	assert.EqualError(t, err, expectedErr)
+	expectedErr = `unexpected type for index: bool`
+	var k bool
+	reg, err := prepareRegister(t, "uint")
+	require.NoError(t, err)
+	err = reg.AddDigest(k, swid.HashEntry{})
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestIntegrityRegisters_AddDigests_NOK(t *testing.T) {
+	expectedErr := `no digests to add`
+	register := IntegrityRegisters{}
+	err := register.AddDigests(uint(0), []swid.HashEntry{})
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestIntegrityRegisters_MarshalCBOR_UIntIndex_OK(t *testing.T) {
+	reg, err := prepareRegister(t, "uint")
+	// Below is the partial CBOR Pretty notation to highlight index as uint: unsigned(0)
+
+	// A5                                      # map(5)
+	//    00                                   # unsigned(0)
+	//    81                                   # array(1)
+	//       82                                # array(2)
+	//          01                             # unsigned(1)
+	//          58 20                          # bytes(32)
+	expected := MustHexDecode(t, "a5008182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75018182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75028182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75038182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75048182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")
+	require.NoError(t, err)
+	actual, err := reg.MarshalCBOR()
+	require.NoError(t, err)
+	fmt.Printf("CBOR Payload = %x\n", actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestIntegrityRegisters_UnmarshalCBOR_UIntIndex_OK(t *testing.T) {
+	expected := IntegrityRegisters{map[IRegisterIndex]Digests{
+		uint64(0): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint64(1): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint64(2): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint64(3): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint64(4): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+	}}
+	bstr := MustHexDecode(nil, `a5008182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75018182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75028182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75038182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75048182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75`)
+	actual := IntegrityRegisters{}
+	err := actual.UnmarshalCBOR(bstr)
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expected, actual))
+}
+
+func TestIntegrityRegisters_MarshalJSON_UIntIndex_OK(t *testing.T) {
+	expected := `{
+		"0": {
+			"key_type": "uint",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"1": {
+			"key_type": "uint",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"2": {
+			"key_type": "uint",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"3": {
+			"key_type": "uint",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"4": {
+			"key_type": "uint",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		}
+	}
+	`
+	reg, err := prepareRegister(t, "uint")
+	require.NoError(t, err)
+	actual, err := reg.MarshalJSON()
+	require.NoError(t, err)
+	assert.JSONEq(t, expected, string(actual))
+}
+
+func TestIntegrityRegisters_MarshalCBOR_TextIndex_OK(t *testing.T) {
+	reg, err := prepareRegister(t, "text")
+	// Below is the partial CBOR Pretty notation to highlight index as text: "0"
+
+	// A5                                   # map(5)
+	// 61                                   # text(1)
+	//    30                                # "0"
+	// 81                                   # array(1)
+	//    82                                # array(2)
+	// 	      01                             # unsigned(1)
+	//  	  58 20                          # bytes(32)
+	expected := MustHexDecode(t, `a561308182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561318182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561328182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561338182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561348182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75`)
+	require.NoError(t, err)
+	actual, err := reg.MarshalCBOR()
+	require.NoError(t, err)
+	fmt.Printf("CBOR Payload = %x\n", actual)
+	assert.Equal(t, expected, actual)
+}
+
+func TestIntegrityRegisters_UnmarshalCBOR_TextIndex_OK(t *testing.T) {
+	expected := IntegrityRegisters{map[IRegisterIndex]Digests{
+		"0": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		"1": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		"2": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		"3": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		"4": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+	}}
+	bstr := MustHexDecode(t, `a561308182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561318182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561328182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561338182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d7561348182015820e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75`)
+	actual := IntegrityRegisters{}
+	err := actual.UnmarshalCBOR(bstr)
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expected, actual))
+}
+
+func TestIntegrityRegisters_MarshalJSON_TextIndex_OK(t *testing.T) {
+	expected := `{
+		"0": {
+			"key_type": "text",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"1": {
+			"key_type": "text",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"2": {
+			"key_type": "text",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"3": {
+			"key_type": "text",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		},
+		"4": {
+			"key_type": "text",
+			"Value": [
+				"sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="
+			]
+		}
+	}
+	`
+	reg, err := prepareRegister(t, "text")
+	require.NoError(t, err)
+	actual, err := reg.MarshalJSON()
+	require.NoError(t, err)
+	fmt.Printf("JSON Payload = %s", actual)
+	assert.JSONEq(t, expected, string(actual))
+}
+
+func TestIntegrityRegisters_UnmarshalJSON_TextIndex_OK(t *testing.T) {
+	j := `{"abcd":{"key_type":"text","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}}`
+	expected := IntegrityRegisters{map[IRegisterIndex]Digests{
+		"abcd": []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+	}}
+	actual := IntegrityRegisters{}
+	err := actual.UnmarshalJSON([]byte(j))
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expected, actual))
+}
+
+func TestIntegrityRegisters_UnmarshalJSON_UIntIndex_OK(t *testing.T) {
+	j := `{
+	"0":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+	"1":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+	"2":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+	"3":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+	"4":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}
+	}`
+	expected := IntegrityRegisters{map[IRegisterIndex]Digests{
+		uint(0): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint(1): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint(2): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint(3): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		uint(4): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+	}}
+	actual := IntegrityRegisters{}
+	err := actual.UnmarshalJSON([]byte(j))
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expected, actual))
+}
+
+func TestIntegrityRegisters_UnmarshalJSON_TextUInt_Index_OK(t *testing.T) {
+	j := `{
+		"0":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+		"1":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+		"2":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+		"3":{"key_type":"text","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]},
+		"4":{"key_type":"text","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}
+		}`
+	expected := IntegrityRegisters{
+		map[IRegisterIndex]Digests{
+			uint(0): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+			uint(1): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+			uint(2): []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+			"3":     []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+			"4":     []swid.HashEntry{{HashAlgID: swid.Sha256, HashValue: MustHexDecode(t, "e45b72f5c0c0b572db4d8d3ab7e97f368ff74e62347a824decb67a84e5224d75")}},
+		}}
+	actual := IntegrityRegisters{}
+	err := actual.UnmarshalJSON([]byte(j))
+	require.NoError(t, err)
+	require.True(t, reflect.DeepEqual(expected, actual))
+}
+
+func TestIntegrityRegisters_UnmarshalJSON_NOK(t *testing.T) {
+	for _, tv := range []struct {
+		Name  string
+		Input string
+		Err   string
+	}{
+		{
+			Name:  "invalid input integer",
+			Input: `{"0":{"key_type":"int","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}}`,
+			Err:   "unexpected key type for index: int",
+		},
+		{
+			Name:  "negative index",
+			Input: `{"-1":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}}`,
+			Err:   `invalid negative integer key`,
+		},
+		{
+			Name:  "not an integer",
+			Input: `{"0.2345":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/No/3TmI0eoJN7LZ6hOUiTXU="]}}`,
+			Err:   `unable to convert key to uint: strconv.Atoi: parsing "0.2345": invalid syntax`,
+		},
+		{
+			Name:  "invalid digest",
+			Input: `{"1":{"key_type":"uint","Value":["sha-256;5Fty9cDAtXLbTY06t+l/3TmI0eoJN7LZ6hOUiTXU="]}}`,
+			Err:   `unable to unmarshal Digests: illegal base64 data at input byte 40`,
+		},
+	} {
+		t.Run(tv.Name, func(t *testing.T) {
+			reg := IntegrityRegisters{}
+			err := reg.UnmarshalJSON([]byte(tv.Input))
+			assert.EqualError(t, err, tv.Err)
+		})
+	}
+}

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -299,18 +299,18 @@ func RegisterMkeyType(tag uint64, factory IMkeyFactory) error {
 
 // Mval stores a measurement-values-map with JSON and CBOR serializations.
 type Mval struct {
-	Ver          *Version  `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	SVN          *SVN      `cbor:"1,keyasint,omitempty" json:"svn,omitempty"`
-	Digests      *Digests  `cbor:"2,keyasint,omitempty" json:"digests,omitempty"`
-	Flags        *FlagsMap `cbor:"3,keyasint,omitempty" json:"flags,omitempty"`
-	RawValue     *RawValue `cbor:"4,keyasint,omitempty" json:"raw-value,omitempty"`
-	RawValueMask *[]byte   `cbor:"5,keyasint,omitempty" json:"raw-value-mask,omitempty"`
-	MACAddr      *MACaddr  `cbor:"6,keyasint,omitempty" json:"mac-addr,omitempty"`
-	IPAddr       *net.IP   `cbor:"7,keyasint,omitempty" json:"ip-addr,omitempty"`
-	SerialNumber *string   `cbor:"8,keyasint,omitempty" json:"serial-number,omitempty"`
-	UEID         *eat.UEID `cbor:"9,keyasint,omitempty" json:"ueid,omitempty"`
-	UUID         *UUID     `cbor:"10,keyasint,omitempty" json:"uuid,omitempty"`
-
+	Ver                *Version            `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	SVN                *SVN                `cbor:"1,keyasint,omitempty" json:"svn,omitempty"`
+	Digests            *Digests            `cbor:"2,keyasint,omitempty" json:"digests,omitempty"`
+	Flags              *FlagsMap           `cbor:"3,keyasint,omitempty" json:"flags,omitempty"`
+	RawValue           *RawValue           `cbor:"4,keyasint,omitempty" json:"raw-value,omitempty"`
+	RawValueMask       *[]byte             `cbor:"5,keyasint,omitempty" json:"raw-value-mask,omitempty"`
+	MACAddr            *MACaddr            `cbor:"6,keyasint,omitempty" json:"mac-addr,omitempty"`
+	IPAddr             *net.IP             `cbor:"7,keyasint,omitempty" json:"ip-addr,omitempty"`
+	SerialNumber       *string             `cbor:"8,keyasint,omitempty" json:"serial-number,omitempty"`
+	UEID               *eat.UEID           `cbor:"9,keyasint,omitempty" json:"ueid,omitempty"`
+	UUID               *UUID               `cbor:"10,keyasint,omitempty" json:"uuid,omitempty"`
+	IntegrityRegisters *IntegrityRegisters `cbor:"14,keyasint,omitempty" json:"integrity-registers,omitempty"`
 	Extensions
 }
 


### PR DESCRIPTION
This PR implements the recently added Integrity Registers (https://ietf-rats-wg.github.io/draft-ietf-rats-corim/draft-ietf-rats-corim.html#name-integrity-registers) to the CoRIM schema.

Fixes #108 