### PR TITLE
Provide missing interface implementations

### DIFF
--- a/comid/classid.go
+++ b/comid/classid.go
@@ -138,10 +138,53 @@ func (o ClassID) String() string {
 	return o.Value.String()
 }
 
+// SetImplID sets the value of the target ClassID to the supplied PSA
+// Implementation ID (see Section 3.2.2 of draft-tschofenig-rats-psa-token)
+func (o *ClassID) SetImplID(implID ImplID) *ClassID {
+	if o != nil {
+		o.Value = TaggedImplID(implID)
+	}
+	return o
+}
+
+// GetImplID retrieves the value of the PSA Implementation ID
+// (see Section 3.2.2 of draft-tschofenig-rats-psa-token) from ClassID
+func (o ClassID) GetImplID() (ImplID, error) {
+	switch t := o.Value.(type) {
+	case *TaggedImplID:
+		return ImplID(*t), nil
+	case TaggedImplID:
+		return ImplID(t), nil
+	default:
+		return ImplID{}, fmt.Errorf("class-id type is: %T", t)
+	}
+}
+
 type IClassIDValue interface {
 	extensions.ITypeChoiceValue
 
 	Bytes() []byte
+}
+
+// SetUUID sets the value of the target ClassID to the supplied UUID
+func (o *ClassID) SetUUID(uuid UUID) *ClassID {
+	if o != nil {
+		o.Value = TaggedUUID(uuid)
+	}
+	return o
+}
+
+// SetOID sets the value of the targed ClassID to the supplied OID.
+// The OID is a string in dotted-decimal notation
+func (o *ClassID) SetOID(s string) *ClassID {
+	if o != nil {
+		var berOID OID
+		if berOID.FromString(s) != nil {
+			return nil
+		}
+		o.Value = TaggedOID(berOID)
+	}
+	return o
 }
 
 const ImplIDType = "psa.impl-id"

--- a/comid/instance.go
+++ b/comid/instance.go
@@ -4,8 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"github.com/google/uuid"
 	"github.com/veraison/corim/encoding"
 	"github.com/veraison/corim/extensions"
+	"github.com/veraison/eat"
 )
 
 // Instance stores an instance identity. The supported formats are UUID, UEID and variable-length opaque bytes.
@@ -119,6 +121,45 @@ func (o Instance) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(value)
+}
+
+// SetUEID sets the identity of the target instance to the supplied UEID
+func (o *Instance) SetUEID(val eat.UEID) *Instance {
+	if o != nil {
+		if val.Validate() != nil {
+			return nil
+		}
+		o.Value = TaggedUEID(val)
+	}
+	return o
+}
+
+// SetUUID sets the identity of the target instance to the supplied UUID
+func (o *Instance) SetUUID(val uuid.UUID) *Instance {
+	if o != nil {
+		o.Value = TaggedUUID(val)
+	}
+	return o
+}
+
+func (o Instance) GetUEID() (eat.UEID, error) {
+	switch t := o.Value.(type) {
+	case TaggedUEID:
+		return eat.UEID(t), nil
+	default:
+		return eat.UEID{}, fmt.Errorf("instance-id type is: %T", t)
+	}
+}
+
+func (o Instance) GetUUID() (UUID, error) {
+	switch t := o.Value.(type) {
+	case *TaggedUUID:
+		return UUID(*t), nil
+	case TaggedUUID:
+		return UUID(t), nil
+	default:
+		return UUID{}, fmt.Errorf("instance-id type is: %T", t)
+	}
 }
 
 // IInstanceValue is the interface implemented by all Instance value

--- a/comid/instance_test.go
+++ b/comid/instance_test.go
@@ -5,15 +5,41 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+func TestInstance_SetUUID_OK(t *testing.T) {
+	inst := &Instance{}
+	testUUID, err := uuid.Parse(TestUUIDString)
+	require.NoError(t, err)
+	i := inst.SetUUID(testUUID)
+	require.NotNil(t, i)
+}
+
 func TestInstance_GetUUID_OK(t *testing.T) {
 	inst := MustNewUUIDInstance(TestUUID)
-	u, ok := inst.Value.(*TaggedUUID)
-	assert.True(t, ok)
-	assert.EqualValues(t, TestUUID, *u)
+	require.NotNil(t, inst)
+	u, err := inst.GetUUID()
+	assert.Nil(t, err)
+	assert.Equal(t, u, TestUUID)
+}
+
+func TestInstance_GetUUID_NOK(t *testing.T) {
+	inst := &Instance{}
+	expectedErr := "instance-id type is: <nil>"
+	_, err := inst.GetUUID()
+	assert.EqualError(t, err, expectedErr)
+}
+
+func TestInstance_SetGetUEID_OK(t *testing.T) {
+	inst := &Instance{}
+	inst = inst.SetUEID(TestUEID)
+	require.NotNil(t, inst)
+	expectedUEID, err := inst.GetUEID()
+	require.NoError(t, err)
+	assert.Equal(t, TestUEID, expectedUEID)
 }
 
 type testInstance string

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -51,6 +51,11 @@ func (o Mkey) IsSet() bool {
 	return o.Value != nil
 }
 
+// Type returns the type of Mkey
+func (o Mkey) Type() string {
+	return o.Value.Type()
+}
+
 // Valid returns nil if the Mkey is valid or an error describing the problem,
 // if it is not.
 func (o Mkey) Valid() error {
@@ -63,6 +68,45 @@ func (o Mkey) Valid() error {
 	}
 
 	return nil
+}
+
+func (o Mkey) GetPSARefValID() (PSARefValID, error) {
+	if !o.IsSet() {
+		return PSARefValID{}, errors.New("MKey is not set")
+	}
+	switch t := o.Value.(type) {
+	case *TaggedPSARefValID:
+		return PSARefValID(*t), nil
+	case TaggedPSARefValID:
+		return PSARefValID(t), nil
+	default:
+		return PSARefValID{}, fmt.Errorf("measurement-key type is: %T", t)
+	}
+}
+
+func (o Mkey) GetCCAPlatformConfigID() (CCAPlatformConfigID, error) {
+	if !o.IsSet() {
+		return "", errors.New("MKey is not set")
+	}
+	switch t := o.Value.(type) {
+	case *TaggedCCAPlatformConfigID:
+		return CCAPlatformConfigID(*t), nil
+	case TaggedCCAPlatformConfigID:
+		return CCAPlatformConfigID(t), nil
+	default:
+		return "", fmt.Errorf("measurement-key type is: %T", t)
+	}
+}
+
+func (o Mkey) GetKeyUint() (uint64, error) {
+	switch t := o.Value.(type) {
+	case UintMkey:
+		return uint64(t), nil
+	case *UintMkey:
+		return uint64(*t), nil
+	default:
+		return MaxUint64, fmt.Errorf("measurement-key type is: %T", t)
+	}
 }
 
 // UnmarshalJSON deserializes the supplied JSON object into the target MKey

--- a/comid/measurement_test.go
+++ b/comid/measurement_test.go
@@ -58,6 +58,33 @@ func TestMeasurement_NewPSAMeasurement_no_values(t *testing.T) {
 	assert.EqualError(t, err, "no measurement value set")
 }
 
+func TestGetPSARefValID(t *testing.T) {
+	psaRefValID, err := NewPSARefValID(TestSignerID)
+	require.NoError(t, err)
+	psaRefValID.SetLabel("PRoT")
+	psaRefValID.SetVersion("1.2.3")
+	mkey, err := NewMkeyPSARefvalID(psaRefValID)
+	require.NoError(t, err)
+	actual, err := mkey.GetPSARefValID()
+	require.NoError(t, err)
+	assert.Equal(t, *psaRefValID, actual)
+}
+
+func TestGetPSARefValID_NOK(t *testing.T) {
+	mkey := &Mkey{}
+	expected := "MKey is not set"
+	_, err := mkey.GetPSARefValID()
+	assert.EqualError(t, err, expected)
+}
+
+func TestGetPSARefValID_InvalidType(t *testing.T) {
+	expected := "measurement-key type is: *comid.TaggedCCAPlatformConfigID"
+	mkey, err := NewMkeyCCAPlatformConfigID(TestCCALabel)
+	require.NoError(t, err)
+	_, err = mkey.GetPSARefValID()
+	assert.EqualError(t, err, expected)
+}
+
 func TestMeasurement_NewCCAPlatCfgMeasurement_no_values(t *testing.T) {
 	ccaplatID := CCAPlatformConfigID(TestCCALabel)
 
@@ -66,6 +93,29 @@ func TestMeasurement_NewCCAPlatCfgMeasurement_no_values(t *testing.T) {
 
 	err = tv.Valid()
 	assert.EqualError(t, err, "no measurement value set")
+}
+
+func TestGetCCAPlatformConfigID(t *testing.T) {
+	ccaplatID := CCAPlatformConfigID(TestCCALabel)
+	mkey, err := NewMkeyCCAPlatformConfigID(TestCCALabel)
+	require.NoError(t, err)
+	actual, err := mkey.GetCCAPlatformConfigID()
+	require.NoError(t, err)
+	assert.Equal(t, ccaplatID, actual)
+}
+
+func TestGetCCAPlatformConfigID_NOK(t *testing.T) {
+	mkey := &Mkey{}
+	expected := "MKey is not set"
+	_, err := mkey.GetCCAPlatformConfigID()
+	assert.EqualError(t, err, expected)
+}
+
+func TestGetCCAPlatformConfigID_InvalidType(t *testing.T) {
+	mkey := &Mkey{UintMkey(10)}
+	expected := "measurement-key type is: comid.UintMkey"
+	_, err := mkey.GetCCAPlatformConfigID()
+	assert.EqualError(t, err, expected)
 }
 
 func TestMeasurement_NewCCAPlatCfgMeasurement_valid_meas(t *testing.T) {


### PR DESCRIPTION
As part of adding extension enhancement to `CoRIM`, part of the interfaces for CoMID library were omitted.
These are required and is been invoked from `veraison/services`.
