### PR TITLE
comid: Add OVMF metadata to the Measurement type

### DIFF
--- a/.github/workflows/ci-go-cover.yml
+++ b/.github/workflows/ci-go-cover.yml
@@ -24,9 +24,9 @@ jobs:
     name: Coverage
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: "1.19"
+        go-version: "1.20"
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install mockgen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ name: ci
 on: [push, pull_request]
 jobs:
 
-  # Test on various OS with default Go version.
+  # Test on various OS with the specified Go version.
   tests:
     name: Test on ${{matrix.os}}
     runs-on: ${{ matrix.os }}
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/setup-go@v3
       with:
-        go-version: "1.19"
+        go-version: "1.20"
     - name: Checkout code
       uses: actions/checkout@v2
       with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -3,20 +3,20 @@ name: linters
 on: [push, pull_request]
 jobs:
 
-  # Check linters on latest-ubuntu with default version of Go.
+  # Check linters on latest-ubuntu with specified version of Go.
   lint:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/setup-go@v2
+    - uses: actions/setup-go@v3
       with:
-        go-version: "1.19"
+        go-version: "1.20"
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Install golangci-lint
       run: |
         go version
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.46.2
+        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v1.58.2
     - name: Install mockgen
       run: |
         go install github.com/golang/mock/mockgen@v1.5.0

--- a/cocli/cmd/comidCreate.go
+++ b/cocli/cmd/comidCreate.go
@@ -42,7 +42,7 @@ func NewComidCreateCmd() *cobra.Command {
 	file name, all the template file names (when from different directories)
 	MUST be different.
 	`,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkComidCreateArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/comidDisplay.go
+++ b/cocli/cmd/comidDisplay.go
@@ -35,7 +35,7 @@ func NewComidDisplayCmd() *cobra.Command {
 	  cocli comid display --file=c1.cbor --file=c2.cbor --dir=comids
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkComidDisplayArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/comidValidate.go
+++ b/cocli/cmd/comidValidate.go
@@ -35,7 +35,7 @@ func NewComidValidateCmd() *cobra.Command {
 	  cocli comid validate --file=c1.cbor --file=c2.cbor --dir=comids
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkComidValidateArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/corimCreate.go
+++ b/cocli/cmd/corimCreate.go
@@ -54,7 +54,7 @@ func NewCorimCreateCmd() *cobra.Command {
 	                   --output=corim.cbor
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCorimCreateArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/corimDisplay.go
+++ b/cocli/cmd/corimDisplay.go
@@ -38,7 +38,7 @@ func NewCorimDisplayCmd() *cobra.Command {
 	  cocli corim display --file yet-another-signed-corim.cbor --show-tags
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCorimDisplayArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/corimExtract.go
+++ b/cocli/cmd/corimExtract.go
@@ -40,7 +40,7 @@ func NewCorimExtractCmd() *cobra.Command {
 	    				--output-dir=my-dir
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCorimExtractArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/corimSign.go
+++ b/cocli/cmd/corimSign.go
@@ -38,7 +38,7 @@ func NewCorimSignCmd() *cobra.Command {
 					--output=signed-corim.cbor
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCorimSignArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/corimSubmit.go
+++ b/cocli/cmd/corimSubmit.go
@@ -46,7 +46,7 @@ func NewCorimSubmitCmd(submitter ISubmitter) *cobra.Command {
 			--media-type="application/corim-unsigned+cbor; profile=http://arm.com/psa/iot/1"
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 
 			if err := checkSubmitArgs(); err != nil {
 				return err

--- a/cocli/cmd/corimVerify.go
+++ b/cocli/cmd/corimVerify.go
@@ -32,7 +32,7 @@ func NewCorimVerifyCmd() *cobra.Command {
 	  cocli corim verify --file=signed-corim.cbor --key=key.jwk
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCorimVerifyArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/cotsCreate.go
+++ b/cocli/cmd/cotsCreate.go
@@ -66,7 +66,7 @@ func NewCotsCreateCtsCmd() *cobra.Command {
 					--output=cots.cbor
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkctsCreateCtsArgs(); err != nil {
 				return err
 			}

--- a/cocli/cmd/cotsDisplay.go
+++ b/cocli/cmd/cotsDisplay.go
@@ -31,7 +31,7 @@ func NewCotsDisplayCmd() *cobra.Command {
 
 	`,
 
-		RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(_ *cobra.Command, _ []string) error {
 			if err := checkCotsDisplayArgs(); err != nil {
 				return err
 			}

--- a/comid/classid_test.go
+++ b/comid/classid_test.go
@@ -373,7 +373,7 @@ func Test_TaggedInt(t *testing.T) {
 
 type testClassID [4]byte
 
-func newTestClassID(val any) (*ClassID, error) {
+func newTestClassID(_ any) (*ClassID, error) {
 	return &ClassID{&testClassID{0x74, 0x65, 0x73, 0x74}}, nil
 }
 

--- a/comid/cryptokey_test.go
+++ b/comid/cryptokey_test.go
@@ -403,7 +403,7 @@ func Test_NewCryptoKey_negative(t *testing.T) {
 
 type testCryptoKey [4]byte
 
-func newTestCryptoKey(val any) (*CryptoKey, error) {
+func newTestCryptoKey(_ any) (*CryptoKey, error) {
 	return &CryptoKey{&testCryptoKey{0x74, 0x64, 0x73, 0x74}}, nil
 }
 

--- a/comid/entity_test.go
+++ b/comid/entity_test.go
@@ -119,7 +119,7 @@ type testEntityNameBadType struct {
 	testEntityName
 }
 
-func newTestEntityNameBadType(val any) (*EntityName, error) {
+func newTestEntityNameBadType(_ any) (*EntityName, error) {
 	v := testEntityNameBadType{testEntityName(7)}
 	return &EntityName{&v}, nil
 }

--- a/comid/extensions_test.go
+++ b/comid/extensions_test.go
@@ -13,23 +13,23 @@ type TestExtension struct {
 	TestFlag *bool
 }
 
-func (o *TestExtension) ConstrainComid(v *Comid) error {
+func (o *TestExtension) ConstrainComid(_ *Comid) error {
 	return errors.New("invalid")
 }
 
-func (o *TestExtension) ValidTriples(v *Triples) error {
+func (o *TestExtension) ValidTriples(_ *Triples) error {
 	return errors.New("invalid")
 }
 
-func (o *TestExtension) ConstrainMval(v *Mval) error {
+func (o *TestExtension) ConstrainMval(_ *Mval) error {
 	return errors.New("invalid")
 }
 
-func (o *TestExtension) ConstrainFlagsMap(v *FlagsMap) error {
+func (o *TestExtension) ConstrainFlagsMap(_ *FlagsMap) error {
 	return errors.New("invalid")
 }
 
-func (o *TestExtension) ConstrainEntity(v *Entity) error {
+func (o *TestExtension) ConstrainEntity(_ *Entity) error {
 	return errors.New("invalid")
 }
 

--- a/comid/group_test.go
+++ b/comid/group_test.go
@@ -11,7 +11,7 @@ import (
 
 type testGroup uint64
 
-func newTestGroup(val any) (*Group, error) {
+func newTestGroup(_ any) (*Group, error) {
 	v := testGroup(7)
 	return &Group{&v}, nil
 }
@@ -37,7 +37,7 @@ type testGroupBadType struct {
 	testGroup
 }
 
-func newTestGroupBadType(val any) (*Group, error) {
+func newTestGroupBadType(_ any) (*Group, error) {
 	v := testGroupBadType{testGroup(7)}
 	return &Group{&v}, nil
 }

--- a/comid/instance_test.go
+++ b/comid/instance_test.go
@@ -44,7 +44,7 @@ func TestInstance_SetGetUEID_OK(t *testing.T) {
 
 type testInstance string
 
-func newTestInstance(val any) (*Instance, error) {
+func newTestInstance(_ any) (*Instance, error) {
 	ret := testInstance("test")
 	return &Instance{&ret}, nil
 }

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -27,7 +27,7 @@ type Mkey struct {
 }
 
 // NewMkey creates a new Mkey of the specfied type using the provided value.
-func NewMkey(val any, typ string) (*Mkey, error) {
+func NewMkey(_ any, typ string) (*Mkey, error) {
 	factory, ok := mkeyValueRegister[typ]
 	if !ok {
 		return nil, fmt.Errorf("unexpected measurement key type: %q", typ)

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -14,6 +14,7 @@ import (
 	"github.com/veraison/corim/extensions"
 	"github.com/veraison/eat"
 	"github.com/veraison/swid"
+	"github.com/virtee/sev-snp-measure-go/ovmf"
 )
 
 const MaxUint64 = ^uint64(0)
@@ -343,18 +344,19 @@ func RegisterMkeyType(tag uint64, factory IMkeyFactory) error {
 
 // Mval stores a measurement-values-map with JSON and CBOR serializations.
 type Mval struct {
-	Ver                *Version            `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
-	SVN                *SVN                `cbor:"1,keyasint,omitempty" json:"svn,omitempty"`
-	Digests            *Digests            `cbor:"2,keyasint,omitempty" json:"digests,omitempty"`
-	Flags              *FlagsMap           `cbor:"3,keyasint,omitempty" json:"flags,omitempty"`
-	RawValue           *RawValue           `cbor:"4,keyasint,omitempty" json:"raw-value,omitempty"`
-	RawValueMask       *[]byte             `cbor:"5,keyasint,omitempty" json:"raw-value-mask,omitempty"`
-	MACAddr            *MACaddr            `cbor:"6,keyasint,omitempty" json:"mac-addr,omitempty"`
-	IPAddr             *net.IP             `cbor:"7,keyasint,omitempty" json:"ip-addr,omitempty"`
-	SerialNumber       *string             `cbor:"8,keyasint,omitempty" json:"serial-number,omitempty"`
-	UEID               *eat.UEID           `cbor:"9,keyasint,omitempty" json:"ueid,omitempty"`
-	UUID               *UUID               `cbor:"10,keyasint,omitempty" json:"uuid,omitempty"`
-	IntegrityRegisters *IntegrityRegisters `cbor:"14,keyasint,omitempty" json:"integrity-registers,omitempty"`
+	Ver                *Version              `cbor:"0,keyasint,omitempty" json:"version,omitempty"`
+	SVN                *SVN                  `cbor:"1,keyasint,omitempty" json:"svn,omitempty"`
+	Digests            *Digests              `cbor:"2,keyasint,omitempty" json:"digests,omitempty"`
+	Flags              *FlagsMap             `cbor:"3,keyasint,omitempty" json:"flags,omitempty"`
+	RawValue           *RawValue             `cbor:"4,keyasint,omitempty" json:"raw-value,omitempty"`
+	RawValueMask       *[]byte               `cbor:"5,keyasint,omitempty" json:"raw-value-mask,omitempty"`
+	MACAddr            *MACaddr              `cbor:"6,keyasint,omitempty" json:"mac-addr,omitempty"`
+	IPAddr             *net.IP               `cbor:"7,keyasint,omitempty" json:"ip-addr,omitempty"`
+	SerialNumber       *string               `cbor:"8,keyasint,omitempty" json:"serial-number,omitempty"`
+	UEID               *eat.UEID             `cbor:"9,keyasint,omitempty" json:"ueid,omitempty"`
+	UUID               *UUID                 `cbor:"10,keyasint,omitempty" json:"uuid,omitempty"`
+	IntegrityRegisters *IntegrityRegisters   `cbor:"14,keyasint,omitempty" json:"integrity-registers,omitempty"`
+	OvmfMetadata       *ovmf.MetadataWrapper `cbor:"15,keyasint,omitempty" json:"ovmf-metadata,omitempty"`
 	Extensions
 }
 
@@ -400,7 +402,8 @@ func (o Mval) Valid() error {
 		o.SerialNumber == nil &&
 		o.UEID == nil &&
 		o.UUID == nil &&
-		o.IntegrityRegisters == nil {
+		o.IntegrityRegisters == nil &&
+		o.OvmfMetadata == nil {
 		return fmt.Errorf("no measurement value set")
 	}
 

--- a/comid/measurement_test.go
+++ b/comid/measurement_test.go
@@ -524,7 +524,7 @@ func TestNewMkeyOID(t *testing.T) {
 
 type testMkey [4]byte
 
-func newTestMkey(val any) (*Mkey, error) {
+func newTestMkey(_ any) (*Mkey, error) {
 	return &Mkey{&testMkey{0x74, 0x64, 0x73, 0x74}}, nil
 }
 
@@ -552,7 +552,7 @@ func (o badMkey) Type() string {
 	return "uuid"
 }
 
-func newBadMkey(val any) (*Mkey, error) {
+func newBadMkey(_ any) (*Mkey, error) {
 	return &Mkey{&badMkey{testMkey{0x74, 0x64, 0x73, 0x74}}}, nil
 }
 

--- a/comid/svn_test.go
+++ b/comid/svn_test.go
@@ -139,7 +139,7 @@ func TestSVN_JSON(t *testing.T) {
 
 type testSVN uint64
 
-func newTestSVN(val any) (*SVN, error) {
+func newTestSVN(_ any) (*SVN, error) {
 	v := testSVN(7)
 	return &SVN{&v}, nil
 }
@@ -160,7 +160,7 @@ type testSVNBadType struct {
 	testSVN
 }
 
-func newTestSVNBadType(val any) (*SVN, error) {
+func newTestSVNBadType(_ any) (*SVN, error) {
 	v := testSVNBadType{testSVN(7)}
 	return &SVN{&v}, nil
 }

--- a/comid/test_vars.go
+++ b/comid/test_vars.go
@@ -36,6 +36,7 @@ var (
 	TestMKey       uint64 = 700
 	TestCCALabel          = "cca-platform-config"
 
+	// #nosec G101
 	TestECPrivKey = `-----BEGIN EC PRIVATE KEY-----
 MHcCAQEEICAm3+mCCDTMuzKqfZso9NT8ur9U9GjuUQ/lNEJvwRFMoAoGCCqGSM49
 AwEHoUQDQgAEW1BvqF+/ry8BWa7ZEMU1xYYHEQ8BlLT4MFHOaO+ICTtIvrEeEpr/

--- a/corim/entity_test.go
+++ b/corim/entity_test.go
@@ -128,7 +128,7 @@ type testEntityNameBadType struct {
 	testEntityName
 }
 
-func newTestEntityNameBadType(val any) (*EntityName, error) {
+func newTestEntityNameBadType(_ any) (*EntityName, error) {
 	v := testEntityNameBadType{testEntityName(7)}
 	return &EntityName{&v}, nil
 }

--- a/corim/extensions_test.go
+++ b/corim/extensions_test.go
@@ -24,11 +24,11 @@ func (o TestExtensions) ConstrainEntity(ent *Entity) error {
 	return nil
 }
 
-func (o TestExtensions) ConstrainCorim(c *UnsignedCorim) error {
+func (o TestExtensions) ConstrainCorim(_ *UnsignedCorim) error {
 	return errors.New("invalid")
 }
 
-func (o TestExtensions) ConstrainSigner(s *Signer) error {
+func (o TestExtensions) ConstrainSigner(_ *Signer) error {
 	return errors.New("invalid")
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,18 +5,19 @@ go 1.18
 require (
 	github.com/fxamacker/cbor/v2 v2.5.0
 	github.com/golang/mock v1.6.0
-	github.com/google/uuid v1.3.0
+	github.com/google/uuid v1.3.1
 	github.com/lestrrat-go/jwx/v2 v2.0.8
 	github.com/spf13/afero v1.9.2
 	github.com/spf13/cast v1.4.1
-	github.com/spf13/cobra v1.2.1
+	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.9.0
-	github.com/stretchr/testify v1.8.2
+	github.com/stretchr/testify v1.8.4
 	github.com/veraison/apiclient v0.2.1-0.20240531100343-8a3a730a1e94
 	github.com/veraison/eat v0.0.0-20210331113810-3da8a4dd42ff
 	github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7
 	github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca
+	github.com/virtee/sev-snp-measure-go v0.0.0-20240530153610-e6e8dc9b6877
 )
 
 require (
@@ -26,7 +27,7 @@ require (
 	github.com/goccy/go-json v0.9.11 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/lestrrat-go/blackmagic v1.0.1 // indirect
 	github.com/lestrrat-go/httpcc v1.0.1 // indirect
 	github.com/lestrrat-go/httprc v1.0.4 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/veraison/corim
 
-go 1.18
+go 1.20
 
 require (
 	github.com/fxamacker/cbor/v2 v2.5.0

--- a/go.sum
+++ b/go.sum
@@ -69,6 +69,7 @@ github.com/cncf/xds/go v0.0.0-20210312221358-fbca930ec8ed/go.mod h1:eXthEFrGJvWH
 github.com/coreos/go-semver v0.3.0/go.mod h1:nnelYz7RCh+5ahJtPPxZlU+153eP4D4r3EedlOD2RNk=
 github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSVTIJ3seZv2GcEnc=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -173,6 +174,8 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/google/uuid v1.3.1 h1:KjJaJ9iWZ3jOFZIf1Lqf4laDRCasjl0BCmnEGxkdLb4=
+github.com/google/uuid v1.3.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/googleapis/gax-go/v2 v2.1.0/go.mod h1:Q3nei7sK6ybPYH7twZdmQpAd1MKb7pfu6SK+H1/DsU0=
@@ -212,6 +215,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/json-iterator/go v1.1.11/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
 github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1:6v2b51hI/fHJwM22ozAgKL4VKDeJcHhJFhtBdhmNjmU=
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
@@ -283,6 +288,7 @@ github.com/prometheus/client_model v0.0.0-20190812154241-14fe0d1b01d4/go.mod h1:
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/sagikazarmark/crypt v0.1.0/go.mod h1:B/mN0msZuINBtQ1zZLEQcegFJJf9vnYIR88KRMEuODE=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
@@ -298,6 +304,8 @@ github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
 github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
 github.com/spf13/cobra v1.2.1/go.mod h1:ExllRjgxM/piMAM+3tAZvg8fsklGAf3tPfi+i8t68Nk=
+github.com/spf13/cobra v1.7.0 h1:hyqWnYt1ZQShIddO5kBpj3vu05/++x6tJ6dg8EC572I=
+github.com/spf13/cobra v1.7.0/go.mod h1:uLxZILRyS/50WlhOIKD7W6V5bgeIt+4sICxh6uRMrb0=
 github.com/spf13/jwalterweatherman v1.1.0 h1:ue6voC5bR5F8YxI5S67j9i582FU4Qvo2bmqnqMYADFk=
 github.com/spf13/jwalterweatherman v1.1.0/go.mod h1:aNWZUN0dPAAO/Ljvb5BEdw96iTZ0EXowPYD95IqWIGo=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -319,6 +327,8 @@ github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
 github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
+github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/subosito/gotenv v1.2.0 h1:Slr1R9HxAlEKefgq5jn9U+DnETlIUa6HfgEzj0g5d7s=
 github.com/subosito/gotenv v1.2.0/go.mod h1:N0PQaV/YGNqwC0u51sEeR/aUtSLEXKX9iv69rRypqCw=
 github.com/veraison/apiclient v0.2.0 h1:QELvZ+eEfzh9v0ORe9B2UTMpiA7aONHpZIfwSfcRR6s=
@@ -331,6 +341,8 @@ github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7 h1:KcKzBthSrSZI
 github.com/veraison/go-cose v1.1.1-0.20230825153510-da0f9a62ade7/go.mod h1:t6V8WJzHm1PD5HNsuDjW3KLv577uWb6UTzbZGvdQHD8=
 github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca h1:osmCKwWO/xM68Kz+rIXio1DNzEY2NdJOpGpoy5r8NlE=
 github.com/veraison/swid v1.1.1-0.20230911094910-8ffdd07a22ca/go.mod h1:d5jt76uMNbTfQ+f2qU4Lt8RvWOTsv6PFgstIM1QdMH0=
+github.com/virtee/sev-snp-measure-go v0.0.0-20240530153610-e6e8dc9b6877 h1:VvG8jLXb2k0pazyXwAyKDhoQJDXOdmwLVUlTlHH9aOU=
+github.com/virtee/sev-snp-measure-go v0.0.0-20240530153610-e6e8dc9b6877/go.mod h1:dEkBe8JnxU5itNjZDEQINFd7f7l4DtjfqRuzPQcit4w=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=


### PR DESCRIPTION
SEV-SNP launch digest is a function of OVMF metadata, among others. Therefore, this patch adds support to add it as a reference value to Veraison.

We need this reference value to compute the SEV-SNP launch digest on-demand.