### PR TITLE
fix: use value receivers for MarshalXXX methods

### DIFF
--- a/comid/classid.go
+++ b/comid/classid.go
@@ -293,8 +293,8 @@ func (o TaggedImplID) Bytes() []byte {
 	return o[:]
 }
 
-func (o *TaggedImplID) MarshalJSON() ([]byte, error) {
-	return json.Marshal((*o)[:])
+func (o TaggedImplID) MarshalJSON() ([]byte, error) {
+	return json.Marshal((o)[:])
 }
 
 func (o *TaggedImplID) UnmarshalJSON(data []byte) error {

--- a/comid/entity.go
+++ b/comid/entity.go
@@ -90,7 +90,7 @@ func (o *Entity) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *Entity) MarshalCBOR() ([]byte, error) {
+func (o Entity) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -100,7 +100,7 @@ func (o *Entity) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *Entity) MarshalJSON() ([]byte, error) {
+func (o Entity) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 

--- a/comid/flagsmap.go
+++ b/comid/flagsmap.go
@@ -197,7 +197,7 @@ func (o *FlagsMap) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *FlagsMap) MarshalCBOR() ([]byte, error) {
+func (o FlagsMap) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -207,7 +207,7 @@ func (o *FlagsMap) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *FlagsMap) MarshalJSON() ([]byte, error) {
+func (o FlagsMap) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -374,7 +374,7 @@ func (o *Mval) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *Mval) MarshalCBOR() ([]byte, error) {
+func (o Mval) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -384,7 +384,7 @@ func (o *Mval) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *Mval) MarshalJSON() ([]byte, error) {
+func (o Mval) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 

--- a/comid/triples.go
+++ b/comid/triples.go
@@ -35,7 +35,7 @@ func (o *Triples) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *Triples) MarshalCBOR() ([]byte, error) {
+func (o Triples) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -45,7 +45,7 @@ func (o *Triples) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *Triples) MarshalJSON() ([]byte, error) {
+func (o Triples) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 

--- a/corim/entity.go
+++ b/corim/entity.go
@@ -103,7 +103,7 @@ func (o *Entity) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *Entity) MarshalCBOR() ([]byte, error) {
+func (o Entity) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -113,7 +113,7 @@ func (o *Entity) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *Entity) MarshalJSON() ([]byte, error) {
+func (o Entity) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 

--- a/corim/meta.go
+++ b/corim/meta.go
@@ -84,7 +84,7 @@ func (o *Signer) UnmarshalCBOR(data []byte) error {
 }
 
 // MarshalCBOR serializes to CBOR
-func (o *Signer) MarshalCBOR() ([]byte, error) {
+func (o Signer) MarshalCBOR() ([]byte, error) {
 	return encoding.SerializeStructToCBOR(em, o)
 }
 
@@ -94,7 +94,7 @@ func (o *Signer) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON serializes to JSON
-func (o *Signer) MarshalJSON() ([]byte, error) {
+func (o Signer) MarshalJSON() ([]byte, error) {
 	return encoding.SerializeStructToJSON(o)
 }
 


### PR DESCRIPTION
Use value, rather than pointer, receivers for MarshalCBOR and MarshalJSON methods. Since those methods don't mutate the structures, pointers are not necessary, and using them prevents the methods from being invoked when marshaling an instance of that structure (rather than a pointer to one). This is not a huge deal as CoRIM fields typically use pointers, however it can lead to surprising results when playing with the structures on their own.