### PR TITLE
refactor(profiles): rename Profile to ProfileManifest and update related functions

### DIFF
--- a/corim/example_profile_test.go
+++ b/corim/example_profile_test.go
@@ -133,13 +133,13 @@ func Example_profile_marshal() {
 		panic(err)
 	}
 
-	profile, ok := GetProfile(profileID)
+	profileManifest, ok := GetProfileManifest(profileID)
 	if !ok {
 		log.Fatalf("profile %v not found", profileID)
 	}
 
-	myCorim := profile.GetUnsignedCorim()
-	myComid := profile.GetComid().
+	myCorim := profileManifest.GetUnsignedCorim()
+	myComid := profileManifest.GetComid().
 		SetLanguage("en-GB").
 		SetTagIdentity("example", 0).
 		// Adding an entity to the Entities collection also registers

--- a/corim/profiles.go
+++ b/corim/profiles.go
@@ -117,9 +117,9 @@ func UnmarshalUnsignedCorimFromJSON(buf []byte) (*UnsignedCorim, error) {
 func UnmarshalComidFromCBOR(buf []byte, profileID *eat.Profile) (*comid.Comid, error) {
 	var ret *comid.Comid
 
-	profile, ok := GetProfile(profileID)
+	profileManifest, ok := GetProfileManifest(profileID)
 	if ok {
-		ret = profile.GetComid()
+		ret = profileManifest.GetComid()
 	} else {
 		ret = comid.NewComid()
 	}
@@ -140,7 +140,7 @@ func GetSignedCorim(profileID *eat.Profile) *SignedCorim {
 	if profileID == nil {
 		ret = NewSignedCorim()
 	} else {
-		profile, ok := GetProfile(profileID)
+		profileManifest, ok := GetProfileManifest(profileID)
 		if !ok {
 			// unknown profile -- treat here like an unprofiled
 			// CoRIM. While the CoRIM spec states that unknown
@@ -153,7 +153,7 @@ func GetSignedCorim(profileID *eat.Profile) *SignedCorim {
 			// additional fields may not be registered.
 			ret = NewSignedCorim()
 		} else {
-			ret = profile.GetSignedCorim()
+			ret = profileManifest.GetSignedCorim()
 		}
 	}
 
@@ -169,7 +169,7 @@ func GetUnsignedCorim(profileID *eat.Profile) *UnsignedCorim {
 	if profileID == nil {
 		ret = NewUnsignedCorim()
 	} else {
-		profile, ok := GetProfile(profileID)
+		profileManifest, ok := GetProfileManifest(profileID)
 		if !ok {
 			// unknown profile -- treat here like an unprofiled
 			// CoRIM. While the CoRIM spec states that unknown
@@ -182,14 +182,14 @@ func GetUnsignedCorim(profileID *eat.Profile) *UnsignedCorim {
 			// additional fields may not be registered.
 			ret = NewUnsignedCorim()
 		} else {
-			ret = profile.GetUnsignedCorim()
+			ret = profileManifest.GetUnsignedCorim()
 		}
 	}
 
 	return ret
 }
 
-// Profile associates an EAT profile ID with a set of extensions. It allows
+// ProfileManifest associates an EAT profile ID with a set of extensions. It allows
 // obtaining new CoRIM and CoMID structures that had associated extensions
 // registered.
 type ProfileManifest struct {
@@ -197,7 +197,7 @@ type ProfileManifest struct {
 	MapExtensions extensions.Map
 }
 
-// GetComid returns a pointer to a new comid.Comid that had the Profile's
+// GetComid returns a pointer to a new comid.Comid that had the ProfileManifest's
 // extensions (if any) registered.
 func (o *ProfileManifest) GetComid() *comid.Comid {
 	ret := comid.NewComid()
@@ -206,7 +206,7 @@ func (o *ProfileManifest) GetComid() *comid.Comid {
 }
 
 // GetUnsignedCorim returns a pointer to a new UnsignedCorim that had the
-// Profile's extensions (if any) registered.
+// ProfileManifest's extensions (if any) registered.
 func (o *ProfileManifest) GetUnsignedCorim() *UnsignedCorim {
 	ret := NewUnsignedCorim()
 	ret.Profile = o.ID
@@ -215,7 +215,7 @@ func (o *ProfileManifest) GetUnsignedCorim() *UnsignedCorim {
 }
 
 // GetSignedCorim returns a pointer to a new SignedCorim that had the
-// Profile's extensions (if any) registered.
+// ProfileManifest's extensions (if any) registered.
 func (o *ProfileManifest) GetSignedCorim() *SignedCorim {
 	ret := NewSignedCorim()
 	ret.UnsignedCorim.Profile = o.ID
@@ -288,10 +288,10 @@ func UnregisterProfile(id *eat.Profile) bool {
 	return false
 }
 
-// GetProfile returns the Profile associated with the specified ID, or an empty
-// profile if no Profile has been registered for the id. The second return
-// value indicates whether a profile for the ID has been found.
-func GetProfile(id *eat.Profile) (ProfileManifest, bool) {
+// GetProfileManifest returns the ProfileManifest associated with the specified ID, or an empty
+// profileManifest if no ProfileManifest has been registered for the id. The second return
+// value indicates whether a profileManifest for the ID has been found.
+func GetProfileManifest(id *eat.Profile) (ProfileManifest, bool) {
 	if id == nil {
 		return ProfileManifest{}, false
 	}

--- a/corim/profiles.go
+++ b/corim/profiles.go
@@ -192,14 +192,14 @@ func GetUnsignedCorim(profileID *eat.Profile) *UnsignedCorim {
 // Profile associates an EAT profile ID with a set of extensions. It allows
 // obtaining new CoRIM and CoMID structures that had associated extensions
 // registered.
-type Profile struct {
+type ProfileManifest struct {
 	ID            *eat.Profile
 	MapExtensions extensions.Map
 }
 
 // GetComid returns a pointer to a new comid.Comid that had the Profile's
 // extensions (if any) registered.
-func (o *Profile) GetComid() *comid.Comid {
+func (o *ProfileManifest) GetComid() *comid.Comid {
 	ret := comid.NewComid()
 	o.registerExtensions(ret, ComidMapExtensionPoints)
 	return ret
@@ -207,7 +207,7 @@ func (o *Profile) GetComid() *comid.Comid {
 
 // GetUnsignedCorim returns a pointer to a new UnsignedCorim that had the
 // Profile's extensions (if any) registered.
-func (o *Profile) GetUnsignedCorim() *UnsignedCorim {
+func (o *ProfileManifest) GetUnsignedCorim() *UnsignedCorim {
 	ret := NewUnsignedCorim()
 	ret.Profile = o.ID
 	o.registerExtensions(ret, UnsignedCorimMapExtensionPoints)
@@ -216,14 +216,14 @@ func (o *Profile) GetUnsignedCorim() *UnsignedCorim {
 
 // GetSignedCorim returns a pointer to a new SignedCorim that had the
 // Profile's extensions (if any) registered.
-func (o *Profile) GetSignedCorim() *SignedCorim {
+func (o *ProfileManifest) GetSignedCorim() *SignedCorim {
 	ret := NewSignedCorim()
 	ret.UnsignedCorim.Profile = o.ID
 	o.registerExtensions(ret, SignedCorimMapExtensionPoints)
 	return ret
 }
 
-func (o *Profile) registerExtensions(e iextensible, points []extensions.Point) {
+func (o *ProfileManifest) registerExtensions(e iextensible, points []extensions.Point) {
 	exts := extensions.NewMap()
 	for _, p := range points {
 		if v, ok := o.MapExtensions[p]; ok {
@@ -262,7 +262,7 @@ func RegisterProfile(id *eat.Profile, exts extensions.Map) error {
 		}
 	}
 
-	profilesRegister[strID] = Profile{ID: id, MapExtensions: exts}
+	profilesRegister[strID] = ProfileManifest{ID: id, MapExtensions: exts}
 
 	return nil
 }
@@ -291,14 +291,14 @@ func UnregisterProfile(id *eat.Profile) bool {
 // GetProfile returns the Profile associated with the specified ID, or an empty
 // profile if no Profile has been registered for the id. The second return
 // value indicates whether a profile for the ID has been found.
-func GetProfile(id *eat.Profile) (Profile, bool) {
+func GetProfile(id *eat.Profile) (ProfileManifest, bool) {
 	if id == nil {
-		return Profile{}, false
+		return ProfileManifest{}, false
 	}
 
 	strID, err := id.Get()
 	if err != nil {
-		return Profile{}, false
+		return ProfileManifest{}, false
 	}
 
 	prof, ok := profilesRegister[strID]
@@ -309,7 +309,7 @@ type iextensible interface {
 	RegisterExtensions(exts extensions.Map) error
 }
 
-var profilesRegister = make(map[string]Profile)
+var profilesRegister = make(map[string]ProfileManifest)
 
 func init() {
 	for _, p := range SignedCorimMapExtensionPoints {

--- a/corim/profiles_test.go
+++ b/corim/profiles_test.go
@@ -65,7 +65,7 @@ func TestProfile_getters(t *testing.T) {
 	id, err := eat.NewProfile("1.2.3")
 	require.NoError(t, err)
 
-	profile := Profile{
+	profile := ProfileManifest{
 		ID: id,
 		MapExtensions: extensions.NewMap().
 			Add(comid.ExtComid, &struct{}{}).

--- a/corim/profiles_test.go
+++ b/corim/profiles_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/veraison/eat"
 )
 
-func TestProfile_registration(t *testing.T) {
+func TestProfileManifest_registration(t *testing.T) {
 	exts := extensions.NewMap()
 
 	err := RegisterProfile(&eat.Profile{}, exts)
@@ -40,11 +40,11 @@ func TestProfile_registration(t *testing.T) {
 	err = RegisterProfile(p2, exts)
 	assert.NoError(t, err)
 
-	prof, ok := GetProfile(p1)
+	prof, ok := GetProfileManifest(p1)
 	assert.True(t, ok)
 	assert.Equal(t, exts, prof.MapExtensions)
 
-	_, ok = GetProfile(&eat.Profile{})
+	_, ok = GetProfileManifest(&eat.Profile{})
 	assert.False(t, ok)
 
 	p3, err := eat.NewProfile("2.3.4")
@@ -61,11 +61,11 @@ func TestProfile_registration(t *testing.T) {
 	UnregisterProfile(p1)
 }
 
-func TestProfile_getters(t *testing.T) {
+func TestProfileManifest_getters(t *testing.T) {
 	id, err := eat.NewProfile("1.2.3")
 	require.NoError(t, err)
 
-	profile := ProfileManifest{
+	profileManifest := ProfileManifest{
 		ID: id,
 		MapExtensions: extensions.NewMap().
 			Add(comid.ExtComid, &struct{}{}).
@@ -73,18 +73,18 @@ func TestProfile_getters(t *testing.T) {
 			Add(ExtSigner, &struct{}{}),
 	}
 
-	c := profile.GetComid()
+	c := profileManifest.GetComid()
 	assert.NotNil(t, c.Extensions.IMapValue)
 
-	u := profile.GetUnsignedCorim()
+	u := profileManifest.GetUnsignedCorim()
 	assert.NotNil(t, u.Extensions.IMapValue)
 
-	s := profile.GetSignedCorim()
+	s := profileManifest.GetSignedCorim()
 	assert.NotNil(t, s.UnsignedCorim.Extensions.IMapValue)
 	assert.NotNil(t, s.Meta.Signer.Extensions.IMapValue)
 }
 
-func TestProfile_marshaling(t *testing.T) {
+func TestProfileManifest_marshaling(t *testing.T) {
 	type corimExtensions struct {
 		Extension1 *string `cbor:"-1,keyasint,omitempty" json:"ext1,omitempty"`
 	}
@@ -117,7 +117,7 @@ func TestProfile_marshaling(t *testing.T) {
 	assert.Equal(t, profID, c.Profile)
 	assert.Equal(t, "foo", c.Extensions.MustGetString("Extension1"))
 
-	profile, ok := GetProfile(c.Profile)
+	profileManifest, ok := GetProfileManifest(c.Profile)
 	assert.True(t, ok)
 
 	cmd, err := UnmarshalComidFromCBOR(c.Tags[0], c.Profile)
@@ -158,11 +158,11 @@ func TestProfile_marshaling(t *testing.T) {
 	assert.Equal(t, profID, c.Profile)
 	assert.Equal(t, "foo", c.Extensions.MustGetString("Extension1"))
 
-	cmd = profile.GetComid()
+	cmd = profileManifest.GetComid()
 	err = cmd.FromJSON(testComidJSON)
 	assert.NoError(t, err)
 
-	cmd = profile.GetComid()
+	cmd = profileManifest.GetComid()
 	err = cmd.FromJSON(testComidWithExtensionsJSON)
 	assert.NoError(t, err)
 

--- a/extensions/README.md
+++ b/extensions/README.md
@@ -209,7 +209,7 @@ func main() {
 
 Map extensions may be grouped into profiles. A profile is registered,
 associating an `eat.Profile` with an `extensions.Map`. A registered profile can
-be obtained by calling `corim.GetProfile()`, which returns a `corim.Profile`
+be obtained by calling `corim.GetProfileManifest()`, which returns a `corim.ProfileManifest`
 object which can be used to obtain `corim.UnsignedCorim`, `corim.SignedCorim`
 and `comid.Comid` instances that have the associated extensions registered.
 `corim.UnmarshalUnsignedCorimFromCBOR()` will automatically look up a


### PR DESCRIPTION
This pull request refactors the Profile struct to ProfileManifest across the codebase to resolve name collisions and improve code clarity.

Changes Made
Renamed the Profile struct to ProfileManifest in:
profiles.go
profiles_test.go
Related methods and variables.
Updated function signatures and internal references to align with the new struct name.
Ensured compatibility with all test cases, and verified that all tests pass successfully.

Why This Change Was Made
The previous implementation used the name Profile for both:
A variable representing eat.Profile (used as a ProfileID).
A struct that associates an eat.Profile with extensions.
This caused name collisions and confusion. Renaming the struct to ProfileManifest resolves these issues and aligns with naming conventions.

Testing
Ran the entire test suite using go test ./... and confirmed all tests passed.
Validated that no functionality was broken after the refactor.
Issue Fixed
This pull request fixes #135 

