### PR TITLE
fix some golangci-lint warnings

### DIFF
--- a/comid/instance_test.go
+++ b/comid/instance_test.go
@@ -108,7 +108,7 @@ func Test_NewBytesInstance_OK(t *testing.T) {
 		instance, err := NewBytesInstance(v)
 		require.NoError(t, err)
 		got := instance.Bytes()
-		assert.Equal(t, testBytes[:], got)
+		assert.Equal(t, testBytes, got)
 	}
 }
 

--- a/cots/cas_and_tas_test.go
+++ b/cots/cas_and_tas_test.go
@@ -145,7 +145,7 @@ func TestTrustAnchor_JSON_Roundtrip(t *testing.T) {
 	err := tv2.FromJSON(j)
 	assert.Nil(t, err)
 
-	assert.True(t, len(tv2.Data) == len(ta) && 0 == bytes.Compare(ta, tv2.Data), "Compare TA value")
+	assert.True(t, len(tv2.Data) == len(ta) && bytes.Equal(ta, tv2.Data), "Compare TA value")
 	assert.True(t, TaFormatCertificate == tv2.Format, "Compare TA format")
 
 }
@@ -166,7 +166,7 @@ func TestTrustAnchor_CBOR_Roundtrip(t *testing.T) {
 	err := tv2.FromCBOR(c)
 	assert.Nil(t, err)
 
-	assert.True(t, len(tv2.Data) == len(ta) && 0 == bytes.Compare(ta, tv2.Data), "Compare TA value")
+	assert.True(t, len(tv2.Data) == len(ta) && bytes.Equal(ta, tv2.Data), "Compare TA value")
 	assert.True(t, TaFormatCertificate == tv2.Format, "Compare TA format")
 
 }
@@ -203,9 +203,9 @@ func TestTasAndCas_JSON_full_Roundtrip(t *testing.T) {
 	err := tv2.FromJSON(j)
 	assert.Nil(t, err)
 
-	assert.True(t, len(tv2.Tas[0].Data) == len(ta) && 0 == bytes.Compare(ta, tv2.Tas[0].Data), "Compare TA value")
+	assert.True(t, len(tv2.Tas[0].Data) == len(ta) && bytes.Equal(ta, tv2.Tas[0].Data), "Compare TA value")
 	assert.True(t, TaFormatCertificate == tv2.Tas[0].Format, "Compare TA format")
-	assert.True(t, len(tv2.Cas[0]) == len(ca) && 0 == bytes.Compare(ca, tv2.Cas[0]), "Compare CA")
+	assert.True(t, len(tv2.Cas[0]) == len(ca) && bytes.Equal(ca, tv2.Cas[0]), "Compare CA")
 }
 
 func TestTasAndCas_CBOR_full_Roundtrip(t *testing.T) {
@@ -221,7 +221,7 @@ func TestTasAndCas_CBOR_full_Roundtrip(t *testing.T) {
 	err := tv2.FromCBOR(c)
 	assert.Nil(t, err)
 
-	assert.True(t, len(tv2.Tas[0].Data) == len(ta) && 0 == bytes.Compare(ta, tv2.Tas[0].Data), "Compare TA value")
+	assert.True(t, len(tv2.Tas[0].Data) == len(ta) && bytes.Equal(ta, tv2.Tas[0].Data), "Compare TA value")
 	assert.True(t, TaFormatCertificate == tv2.Tas[0].Format, "Compare TA format")
 	assert.True(t, TaFormatCertificate == tv2.Tas[0].Format, "Compare TA format")
 }

--- a/cots/cots.go
+++ b/cots/cots.go
@@ -34,7 +34,7 @@ func (o *ConciseTaStore) SetTagIdentity(tagID interface{}, tagIDVersion *uint) *
 		}
 		o.TagIdentity = &comid.TagIdentity{}
 		o.TagIdentity.TagID = *id
-		if nil != tagIDVersion {
+		if tagIDVersion != nil {
 			o.TagIdentity.TagVersion = *tagIDVersion
 		}
 	}

--- a/cots/eat_cwtclaims_test.go
+++ b/cots/eat_cwtclaims_test.go
@@ -67,7 +67,7 @@ func getNonce() eat.Nonce {
 	return nonce
 }
 
-func cborRoundTripper(t *testing.T, tv EatCWTClaim, expected []byte) {
+func cborRoundTripper(t *testing.T, tv *EatCWTClaim, expected []byte) {
 	data, err := tv.ToCBOR()
 
 	t.Logf("CBOR: %x", data)
@@ -79,10 +79,10 @@ func cborRoundTripper(t *testing.T, tv EatCWTClaim, expected []byte) {
 	err = actual.FromCBOR(data)
 
 	assert.Nil(t, err)
-	assert.Equal(t, tv, actual)
+	assert.Equal(t, *tv, actual)
 }
 
-func jsonRoundTripper(t *testing.T, tv EatCWTClaim, expected string) {
+func jsonRoundTripper(t *testing.T, tv *EatCWTClaim, expected string) {
 	data, err := tv.ToJSON()
 
 	t.Logf("JSON: '%s'", string(data))
@@ -94,7 +94,7 @@ func jsonRoundTripper(t *testing.T, tv EatCWTClaim, expected string) {
 	err = actual.FromJSON(data)
 
 	assert.Nil(t, err)
-	assert.Equal(t, tv, actual)
+	assert.Equal(t, *tv, actual)
 }
 
 func TestEatCWTClaim_Full_RoundtripCBOR(t *testing.T) {
@@ -116,7 +116,7 @@ func TestEatCWTClaim_Full_RoundtripCBOR(t *testing.T) {
 		0xff, 0xff, 0xff, 0xff, 0xff,
 	}
 
-	cborRoundTripper(t, tv, expected)
+	cborRoundTripper(t, &tv, expected)
 }
 
 func TestEatCWTClaim_Full_RoundtripJSON(t *testing.T) {
@@ -143,7 +143,7 @@ func TestEatCWTClaim_Full_RoundtripJSON(t *testing.T) {
 	"iat": 0,
 	"cti": "////////"
 }`
-	jsonRoundTripper(t, tv, expected)
+	jsonRoundTripper(t, &tv, expected)
 }
 
 func TestEatCWTClaims_Valid_empty_list(t *testing.T) {

--- a/encoding/cbor.go
+++ b/encoding/cbor.go
@@ -261,13 +261,13 @@ func (o *structFieldsCBOR) ToCBOR(em cbor.EncMode) ([]byte, error) {
 		header |= byte(25)
 		out = append(out, header)
 		out = binary.BigEndian.AppendUint16(out, uint16(mapLen))
-	} else {
+	} else if mapLen <= math.MaxUint32 {
 		header |= byte(26)
 		out = append(out, header)
 		out = binary.BigEndian.AppendUint32(out, uint32(mapLen))
+	} else {
+		return nil, errors.New("mapLen cannot exceed math.MaxUint32")
 	}
-	// Since len() returns an int, the value cannot exceed MaxUint32, so
-	// the 8-byte length variant cannot occur.
 
 	for _, key := range o.Keys {
 		marshalledKey, err := em.Marshal(key)


### PR DESCRIPTION
- change the `tv` parameter in the `cborRoundTripper` and `jsonRoundTripper` functions to a pointer in `cots/eat_cwtclaims_test.go`
- remove the unnecessary slicing in `comid/instance_test.go`
- change `0 == bytes.Compare(a, b)` to `bytes.Equal(a, b)` in `cots/cas_and_tas_test.go`
- return an error if `mapLen > math.MaxUint32` in `encoding/cbor.go`

This is a pretty small PR to get familiar with the codebase. I'm also not sure if this would be a useful PR as `make presubmit` gives a lot of other errors. Let me know if I should fix the others as well.