### PR TITLE
Refactor SVN Value Conversion Logic into a Separate Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,13 @@ The [`corim/corim`](corim) and [`corim/comid`](comid) packages provide a golang 
 > These API are still in active development (as is the underlying CoRIM spec).
 > They are **subject to change** in the future.
 
+## Required Tools
+
+Ensure you have the following tools installed with the specified versions on your machine to ensure everything works properly:
+
+- **Go**: Version 1.22
+- **golangci-lint**: Version 1.54.2
+
 ## Developer tips
 
 Before requesting a PR (and routinely during the dev/test cycle), you are encouraged to run:

--- a/comid/svn.go
+++ b/comid/svn.go
@@ -183,31 +183,40 @@ func (o TaggedMinSVN) Valid() error {
 }
 
 // This function converts various types to uint64 for SVN.
+// convertToSVNUint64 converts various types to uint64 for SVN
 func convertToSVNUint64(val any) (uint64, error) {
-	switch t := val.(type) {
-	case string:
-		u, err := strconv.ParseUint(t, 10, 64)
-		if err != nil {
-			return 0, err
-		}
-		return u, nil
-	case uint64:
-		return t, nil
-	case uint:
-		return uint64(t), nil
-	case int:
-		if t < 0 {
-			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		return uint64(t), nil
-	case int64:
-		if t < 0 {
-			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		return uint64(t), nil
-	default:
-		return 0, fmt.Errorf("unexpected type for SVN: %T", t)
-	}
+    switch t := val.(type) {
+    case string:
+        u, err := strconv.ParseUint(t, 10, 64)
+        if err != nil {
+            return 0, err
+        }
+        return u, nil
+    case uint64:
+        return t, nil
+    case uint:
+        return uint64(t), nil
+    case int:
+        if t < 0 {
+            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+        }
+        return uint64(t), nil
+    case int64:
+        if t < 0 {
+            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+        }
+        return uint64(t), nil
+    case TaggedSVN:
+        return uint64(t), nil
+    case *TaggedSVN:
+        return uint64(*t), nil
+    case TaggedMinSVN:
+        return uint64(t), nil
+    case *TaggedMinSVN:
+        return uint64(*t), nil
+    default:
+        return 0, fmt.Errorf("unexpected type for SVN: %T", t)
+    }
 }
 
 // ISVNFactory defines the signature for the factory functions that may be

--- a/comid/svn.go
+++ b/comid/svn.go
@@ -183,40 +183,39 @@ func (o TaggedMinSVN) Valid() error {
 }
 
 // This function converts various types to uint64 for SVN.
-// convertToSVNUint64 converts various types to uint64 for SVN
 func convertToSVNUint64(val any) (uint64, error) {
-    switch t := val.(type) {
-    case string:
-        u, err := strconv.ParseUint(t, 10, 64)
-        if err != nil {
-            return 0, err
-        }
-        return u, nil
-    case uint64:
-        return t, nil
-    case uint:
-        return uint64(t), nil
-    case int:
-        if t < 0 {
-            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-        }
-        return uint64(t), nil
-    case int64:
-        if t < 0 {
-            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-        }
-        return uint64(t), nil
-    case TaggedSVN:
-        return uint64(t), nil
-    case *TaggedSVN:
-        return uint64(*t), nil
-    case TaggedMinSVN:
-        return uint64(t), nil
-    case *TaggedMinSVN:
-        return uint64(*t), nil
-    default:
-        return 0, fmt.Errorf("unexpected type for SVN: %T", t)
-    }
+	switch t := val.(type) {
+	case string:
+		u, err := strconv.ParseUint(t, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return u, nil
+	case uint64:
+		return t, nil
+	case uint:
+		return uint64(t), nil
+	case int:
+		if t < 0 {
+			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+		}
+		return uint64(t), nil
+	case int64:
+		if t < 0 {
+			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+		}
+		return uint64(t), nil
+	case TaggedSVN:
+		return uint64(t), nil
+	case *TaggedSVN:
+		return uint64(*t), nil
+	case TaggedMinSVN:
+		return uint64(t), nil
+	case *TaggedMinSVN:
+		return uint64(*t), nil
+	default:
+		return 0, fmt.Errorf("unexpected type for SVN: %T", t)
+	}
 }
 
 // ISVNFactory defines the signature for the factory functions that may be

--- a/comid/svn.go
+++ b/comid/svn.go
@@ -182,7 +182,7 @@ func (o TaggedMinSVN) Valid() error {
 	return nil
 }
 
-// This function converts various types to uint64 for SVN.
+// convertToSVNUint64 converts various SVN types to uint64.
 func convertToSVNUint64(val any) (uint64, error) {
 	switch t := val.(type) {
 	case string:

--- a/comid/svn.go
+++ b/comid/svn.go
@@ -107,42 +107,19 @@ const (
 type TaggedSVN uint64
 
 func NewTaggedSVN(val any) (*SVN, error) {
-	var ret TaggedSVN
+    var ret TaggedSVN
 
-	if val == nil {
-		return &SVN{&ret}, nil
-	}
+    if val == nil {
+        return &SVN{&ret}, nil
+    }
 
-	switch t := val.(type) {
-	case string:
-		u, err := strconv.ParseUint(t, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		ret = TaggedSVN(u)
-	case TaggedSVN:
-		ret = t
-	case *TaggedSVN:
-		ret = *t
-	case uint64:
-		ret = TaggedSVN(t)
-	case uint:
-		ret = TaggedSVN(t)
-	case int:
-		if t < 0 {
-			return nil, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		ret = TaggedSVN(t)
-	case int64:
-		if t < 0 {
-			return nil, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		ret = TaggedSVN(t)
-	default:
-		return nil, fmt.Errorf("unexpected type for SVN exact-value: %T", t)
-	}
+    u, err := convertToSVNUint64(val)
+    if err != nil {
+        return nil, err
+    }
+    ret = TaggedSVN(u)
 
-	return &SVN{&ret}, nil
+    return &SVN{&ret}, nil
 }
 
 func MustNewTaggedSVN(val any) *SVN {
@@ -169,42 +146,19 @@ func (o TaggedSVN) Valid() error {
 type TaggedMinSVN uint64
 
 func NewTaggedMinSVN(val any) (*SVN, error) {
-	var ret TaggedMinSVN
+    var ret TaggedMinSVN
 
-	if val == nil {
-		return &SVN{&ret}, nil
-	}
+    if val == nil {
+        return &SVN{&ret}, nil
+    }
 
-	switch t := val.(type) {
-	case string:
-		u, err := strconv.ParseUint(t, 10, 64)
-		if err != nil {
-			return nil, err
-		}
-		ret = TaggedMinSVN(u)
-	case TaggedMinSVN:
-		ret = t
-	case *TaggedMinSVN:
-		ret = *t
-	case uint64:
-		ret = TaggedMinSVN(t)
-	case uint:
-		ret = TaggedMinSVN(t)
-	case int:
-		if t < 0 {
-			return nil, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		ret = TaggedMinSVN(t)
-	case int64:
-		if t < 0 {
-			return nil, fmt.Errorf("SVN cannot be negative: %d", t)
-		}
-		ret = TaggedMinSVN(t)
-	default:
-		return nil, fmt.Errorf("unexpected type for SVN min-value: %T", t)
-	}
+    u, err := convertToSVNUint64(val)
+    if err != nil {
+        return nil, err
+    }
+    ret = TaggedMinSVN(u)
 
-	return &SVN{&ret}, nil
+    return &SVN{&ret}, nil
 }
 
 func MustNewTaggedMinSVN(val any) *SVN {
@@ -226,6 +180,34 @@ func (o TaggedMinSVN) Type() string {
 
 func (o TaggedMinSVN) Valid() error {
 	return nil
+}
+
+// This function converts various types to uint64 for SVN.
+func convertToSVNUint64(val any) (uint64, error) {
+    switch t := val.(type) {
+    case string:
+        u, err := strconv.ParseUint(t, 10, 64)
+        if err != nil {
+            return 0, err
+        }
+        return u, nil
+    case uint64:
+        return t, nil
+    case uint:
+        return uint64(t), nil
+    case int:
+        if t < 0 {
+            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+        }
+        return uint64(t), nil
+    case int64:
+        if t < 0 {
+            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+        }
+        return uint64(t), nil
+    default:
+        return 0, fmt.Errorf("unexpected type for SVN: %T", t)
+    }
 }
 
 // ISVNFactory defines the signature for the factory functions that may be

--- a/comid/svn.go
+++ b/comid/svn.go
@@ -107,19 +107,19 @@ const (
 type TaggedSVN uint64
 
 func NewTaggedSVN(val any) (*SVN, error) {
-    var ret TaggedSVN
+	var ret TaggedSVN
 
-    if val == nil {
-        return &SVN{&ret}, nil
-    }
+	if val == nil {
+		return &SVN{&ret}, nil
+	}
 
-    u, err := convertToSVNUint64(val)
-    if err != nil {
-        return nil, err
-    }
-    ret = TaggedSVN(u)
+	u, err := convertToSVNUint64(val)
+	if err != nil {
+		return nil, err
+	}
+	ret = TaggedSVN(u)
 
-    return &SVN{&ret}, nil
+	return &SVN{&ret}, nil
 }
 
 func MustNewTaggedSVN(val any) *SVN {
@@ -146,19 +146,19 @@ func (o TaggedSVN) Valid() error {
 type TaggedMinSVN uint64
 
 func NewTaggedMinSVN(val any) (*SVN, error) {
-    var ret TaggedMinSVN
+	var ret TaggedMinSVN
 
-    if val == nil {
-        return &SVN{&ret}, nil
-    }
+	if val == nil {
+		return &SVN{&ret}, nil
+	}
 
-    u, err := convertToSVNUint64(val)
-    if err != nil {
-        return nil, err
-    }
-    ret = TaggedMinSVN(u)
+	u, err := convertToSVNUint64(val)
+	if err != nil {
+		return nil, err
+	}
+	ret = TaggedMinSVN(u)
 
-    return &SVN{&ret}, nil
+	return &SVN{&ret}, nil
 }
 
 func MustNewTaggedMinSVN(val any) *SVN {
@@ -184,30 +184,30 @@ func (o TaggedMinSVN) Valid() error {
 
 // This function converts various types to uint64 for SVN.
 func convertToSVNUint64(val any) (uint64, error) {
-    switch t := val.(type) {
-    case string:
-        u, err := strconv.ParseUint(t, 10, 64)
-        if err != nil {
-            return 0, err
-        }
-        return u, nil
-    case uint64:
-        return t, nil
-    case uint:
-        return uint64(t), nil
-    case int:
-        if t < 0 {
-            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-        }
-        return uint64(t), nil
-    case int64:
-        if t < 0 {
-            return 0, fmt.Errorf("SVN cannot be negative: %d", t)
-        }
-        return uint64(t), nil
-    default:
-        return 0, fmt.Errorf("unexpected type for SVN: %T", t)
-    }
+	switch t := val.(type) {
+	case string:
+		u, err := strconv.ParseUint(t, 10, 64)
+		if err != nil {
+			return 0, err
+		}
+		return u, nil
+	case uint64:
+		return t, nil
+	case uint:
+		return uint64(t), nil
+	case int:
+		if t < 0 {
+			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+		}
+		return uint64(t), nil
+	case int64:
+		if t < 0 {
+			return 0, fmt.Errorf("SVN cannot be negative: %d", t)
+		}
+		return uint64(t), nil
+	default:
+		return 0, fmt.Errorf("unexpected type for SVN: %T", t)
+	}
 }
 
 // ISVNFactory defines the signature for the factory functions that may be

--- a/comid/svn_test.go
+++ b/comid/svn_test.go
@@ -103,7 +103,7 @@ func Test_NewSVN(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = NewSVN(true, "exact-value")
-	assert.EqualError(t, err, "unexpected type for SVN exact-value: bool")
+	assert.EqualError(t, err, "unexpected type for SVN: bool")
 
 	inMin := TaggedMinSVN(7)
 
@@ -114,7 +114,7 @@ func Test_NewSVN(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = NewSVN(true, "min-value")
-	assert.EqualError(t, err, "unexpected type for SVN min-value: bool")
+	assert.EqualError(t, err, "unexpected type for SVN: bool")
 
 	_, err = NewSVN(true, "test")
 	assert.EqualError(t, err, "unknown SVN type: test")


### PR DESCRIPTION
Refactors the SVN value conversion logic into a separate function to improve readability and maintainability. The newly created function handles the conversion of various types to for SVN.

Changes made :- 

A new function convertToSVNUint64() is created to handle the conversion of various types to uint64 for SVN. Existing functions in svn.go NewTaggedSVN() and NewTaggedMinSVN() have been refactored to use this newly created function convertToSVNUint64().