### PR TITLE
fix(corim): handle silly RFC9360 microoptimisation

### DIFF
--- a/corim/signedcorim.go
+++ b/corim/signedcorim.go
@@ -72,7 +72,7 @@ func (o *SignedCorim) processHdrs() error {
 
 	// TODO(tho) key id is apparently mandatory, which doesn't look right.
 	// TODO(tho) Check with the CoRIM design team.
-	// See https://github.com/veraison/corim/issues/14
+	// See https://github.com/ietf-rats-wg/draft-ietf-rats-corim/issues/363
 
 	if v, ok := hdr.Protected[HeaderLabelCorimMeta]; ok {
 		if err := o.extractMeta(v); err != nil {


### PR DESCRIPTION
x5chain is of type `COSE_X509`, which is defined as:
    
    COSE_X509 = bstr / [ 2*certs: bstr ]
    
If there is only one element, it should be encoded as a simple `bstr` instead of being represented as an array.