### PR TITLE
fix: handle short buffers inside UnsignedCorim.FromCBOR()

### DIFF
--- a/corim/unsignedcorim.go
+++ b/corim/unsignedcorim.go
@@ -302,6 +302,10 @@ func (o UnsignedCorim) ToCBOR() ([]byte, error) {
 
 // FromCBOR deserializes a CBOR-encoded unsigned CoRIM into the target UnsignedCorim
 func (o *UnsignedCorim) FromCBOR(data []byte) error {
+	if len(data) < 3 {
+		return errors.New("input too short")
+	}
+
 	if !bytes.Equal(data[:3], UnsignedCorimTag) {
 		return errors.New("did not see unsigned CoRIM tag")
 	}

--- a/corim/unsignedcorim_test.go
+++ b/corim/unsignedcorim_test.go
@@ -404,6 +404,12 @@ func TestUnsignedCorim_extensions(t *testing.T) {
 	assert.EqualError(t, err, `unexpected extension point: "test"`)
 }
 
+func TestUnsignedCorim_truncated(t *testing.T) {
+	c := NewUnsignedCorim()
+	err := c.FromCBOR([]byte{0x01, 0x02})
+	assert.EqualError(t, err, "input too short")
+}
+
 func TestLocator_Valid(t *testing.T) {
 	l := Locator{}
 	assert.EqualError(t, l.Valid(), "empty href")


### PR DESCRIPTION
UnsignedCorim.FromCBOR() checks for the unsigned  corim tag by taking a slice of the first three bytes of the input. This will panic if the input is shorter than three bytes, so check for that first.