### PR TITLE
fixed  allow indefLength across cbor.go files

### DIFF
--- a/coev/cbor.go
+++ b/coev/cbor.go
@@ -39,7 +39,7 @@ func coevTags() cbor.TagSet {
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
 		Sort:        cbor.SortCoreDeterministic,
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncModeWithTags(coevTags())
@@ -47,7 +47,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(coevTags())
 }

--- a/comid/cbor.go
+++ b/comid/cbor.go
@@ -59,7 +59,7 @@ func comidTags() cbor.TagSet {
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
 		Sort:        cbor.SortCoreDeterministic,
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncModeWithTags(comidTags())
@@ -67,7 +67,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(comidTags())
 }

--- a/comid/tdx/cbor.go
+++ b/comid/tdx/cbor.go
@@ -41,7 +41,7 @@ func tdxTags() cbor.TagSet {
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
 		Sort:        cbor.SortCoreDeterministic,
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncModeWithTags(tdxTags())
@@ -49,7 +49,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(tdxTags())
 }

--- a/corim/cbor.go
+++ b/corim/cbor.go
@@ -45,7 +45,7 @@ func corimTags() cbor.TagSet {
 
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncModeWithTags(corimTags())
@@ -53,7 +53,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.DecTagRequired,
 	}
 	return decOpt.DecModeWithTags(corimTags())

--- a/cots/cbor.go
+++ b/cots/cbor.go
@@ -42,7 +42,7 @@ func cotsTags() cbor.TagSet {
 
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncModeWithTags(cotsTags())
@@ -50,7 +50,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.DecTagRequired,
 	}
 	return decOpt.DecModeWithTags(cotsTags())

--- a/extensions/cbor.go
+++ b/extensions/cbor.go
@@ -15,7 +15,7 @@ var (
 func initCBOREncMode() (en cbor.EncMode, err error) {
 	encOpt := cbor.EncOptions{
 		Sort:        cbor.SortCoreDeterministic,
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.EncTagRequired,
 	}
 	return encOpt.EncMode()
@@ -23,7 +23,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecMode()
 }


### PR DESCRIPTION
To fix the issue #211  across cbor.go file, changed  cbor.IndefLengthForbidden to  cbor.IndefLengthAllowed. Also run all the testcases and all the testcases got passed . 

ok      github.com/veraison/corim/coev  (cached)
ok      github.com/veraison/corim/coev/tdx      (cached)
ok      github.com/veraison/corim/comid (cached)
ok      github.com/veraison/corim/comid/tdx     (cached)
ok      github.com/veraison/corim/corim (cached)
ok      github.com/veraison/corim/coserv        (cached)
ok      github.com/veraison/corim/cots  (cached)
ok      github.com/veraison/corim/encoding      (cached)
ok      github.com/veraison/corim/extensions    (cached)

If anything more to be done from my side , kindly tell me , this is my first PR to a open source project . If i have done anything wrong or any mistake , my apologies. Please review and give feedback . I want to collaborate and learn from community.