### PR TITLE
Changed profile identifiers from HTTP URLs to tag URIs (RFC 4151)

### DIFF
--- a/comid/cca/README.md
+++ b/comid/cca/README.md
@@ -1,0 +1,51 @@
+# CCA (Confidential Computing Architecture) Profiles
+
+This package defines CCA profile identifiers using the tag URI scheme as specified in [RFC 4151](https://tools.ietf.org/html/rfc4151).
+
+## Profile Identifiers
+
+Three profile identifiers are defined:
+
+1. **CCA Token Profile**
+   ```
+   tag:arm.com,2025:cca-token
+   ```
+   Used for CCA attestation tokens.
+
+2. **CCA Platform Endorsements Profile**
+   ```
+   tag:arm.com,2025:cca-endorsements
+   ```
+   Used for CCA platform endorsements.
+
+3. **CCA Realm Endorsements Profile**
+   ```
+   tag:arm.com,2025:cca-realm-endorsements
+   ```
+   Used for CCA realm endorsements.
+
+## Usage
+
+```go
+import "github.com/veraison/corim/comid/cca"
+
+func example() {
+    // Use CCA Token Profile
+    tokenProfile := cca.TokenProfileID
+
+    // Use CCA Platform Endorsements Profile
+    platformProfile := cca.EndorsementsProfileID
+
+    // Use CCA Realm Endorsements Profile
+    realmProfile := cca.RealmEndorsementsProfileID
+}
+```
+
+## Tag URI Format
+
+The tag URIs follow RFC 4151 format:
+- Authority: `arm.com` - representing Arm Limited
+- Date: `2025` - year of profile definition
+- Specific ID: One of `cca-token`, `cca-endorsements`, or `cca-realm-endorsements`
+
+These tag URIs are used instead of HTTP URLs to avoid accidental dereferencing while maintaining unique identification.

--- a/comid/cca/profiles.go
+++ b/comid/cca/profiles.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cca
+
+import (
+	"github.com/veraison/eat"
+)
+
+var (
+	// CCA Token Profile ID using tag URI scheme
+	TokenProfileID *eat.Profile
+
+	// CCA Platform Endorsements Profile ID using tag URI scheme
+	EndorsementsProfileID *eat.Profile 
+
+	// CCA Realm Endorsements Profile ID using tag URI scheme
+	RealmEndorsementsProfileID *eat.Profile
+)
+
+func init() {
+	var err error
+
+	TokenProfileID, err = eat.NewProfile("tag:arm.com,2025:cca-token")
+	if err != nil {
+		panic(err)
+	}
+
+	EndorsementsProfileID, err = eat.NewProfile("tag:arm.com,2025:cca-endorsements")
+	if err != nil {
+		panic(err)
+	}
+
+	RealmEndorsementsProfileID, err = eat.NewProfile("tag:arm.com,2025:cca-realm-endorsements")
+	if err != nil {
+		panic(err)
+	}
+}

--- a/comid/cca/profiles_test.go
+++ b/comid/cca/profiles_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cca
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/eat"
+)
+
+func TestCCAProfiles_URIFormat(t *testing.T) {
+	// Verify Token Profile ID
+	assert.Equal(t,
+		"tag:arm.com,2025:cca-token",
+		TokenProfileID.String(),
+		"TokenProfileID should use tag URI scheme",
+	)
+
+	// Verify Platform Endorsements Profile ID
+	assert.Equal(t,
+		"tag:arm.com,2025:cca-endorsements",
+		EndorsementsProfileID.String(),
+		"EndorsementsProfileID should use tag URI scheme",
+	)
+
+	// Verify Realm Endorsements Profile ID
+	assert.Equal(t,
+		"tag:arm.com,2025:cca-realm-endorsements",
+		RealmEndorsementsProfileID.String(),
+		"RealmEndorsementsProfileID should use tag URI scheme",
+	)
+}
+
+func TestCCAProfiles_Validation(t *testing.T) {
+	// Test valid tag URIs can be created
+	tests := []struct {
+		name string
+		uri string
+	}{
+		{
+			name: "Token Profile",
+			uri: "tag:arm.com,2025:cca-token",
+		},
+		{
+			name: "Platform Endorsements Profile",
+			uri: "tag:arm.com,2025:cca-endorsements",
+		},
+		{
+			name: "Realm Endorsements Profile",
+			uri: "tag:arm.com,2025:cca-realm-endorsements",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := eat.NewProfile(tt.uri)
+			require.NoError(t, err)
+			require.NotNil(t, profile)
+			assert.Equal(t, tt.uri, profile.String())
+		})
+	}
+}
+
+func TestCCAProfiles_InvalidURIs(t *testing.T) {
+	// Test invalid URIs are rejected
+	tests := []struct {
+		name string
+		uri string
+	}{
+		{
+			name: "HTTP URL instead of tag URI",
+			uri: "http://arm.com/cca-token",
+		},
+		{
+			name: "Missing date",
+			uri: "tag:arm.com:cca-token",
+		},
+		{
+			name: "Invalid date",
+			uri: "tag:arm.com,abcd:cca-token",
+		},
+		{
+			name: "Empty specific part",
+			uri: "tag:arm.com,2025:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := eat.NewProfile(tt.uri)
+			if err == nil {
+				t.Errorf("Expected error for invalid URI %q, got nil", tt.uri)
+			}
+			assert.Nil(t, profile)
+		})
+	}
+}
+
+func TestCCAProfiles_Equality(t *testing.T) {
+	// Test profile equality
+	token1, err := eat.NewProfile("tag:arm.com,2025:cca-token")
+	require.NoError(t, err)
+	token2, err := eat.NewProfile("tag:arm.com,2025:cca-token")
+	require.NoError(t, err)
+	endorsements, err := eat.NewProfile("tag:arm.com,2025:cca-endorsements")
+	require.NoError(t, err)
+
+	// Same profile URIs should be equal
+	assert.Equal(t, token1, token2)
+
+	// Different profile URIs should not be equal
+	assert.NotEqual(t, token1, endorsements)
+}

--- a/comid/psa/README.md
+++ b/comid/psa/README.md
@@ -1,0 +1,42 @@
+# PSA (Platform Security Architecture) Profiles
+
+This package defines PSA profile identifiers using the tag URI scheme as specified in [RFC 4151](https://tools.ietf.org/html/rfc4151).
+
+## Profile Identifiers
+
+Two profile identifiers are defined:
+
+1. **PSA Token Profile**
+   ```
+   tag:trustedcomputinggroup.org,2025:psa-token
+   ```
+   Used for PSA attestation tokens as defined in [draft-tschofenig-rats-psa-token](https://datatracker.ietf.org/doc/html/draft-tschofenig-rats-psa-token).
+
+2. **PSA Platform Endorsements Profile**
+   ```
+   tag:trustedcomputinggroup.org,2025:psa-endorsements
+   ```
+   Used for PSA platform endorsements.
+
+## Usage
+
+```go
+import "github.com/veraison/corim/comid/psa"
+
+func example() {
+    // Use PSA Token Profile
+    tokenProfile := psa.TokenProfileID
+
+    // Use PSA Endorsements Profile
+    endorsementsProfile := psa.EndorsementsProfileID
+}
+```
+
+## Tag URI Format
+
+The tag URIs follow RFC 4151 format:
+- Authority: `trustedcomputinggroup.org` - representing the TCG organization
+- Date: `2025` - year of profile definition
+- Specific ID: Either `psa-token` or `psa-endorsements`
+
+These tag URIs are used instead of HTTP URLs to avoid accidental dereferencing while maintaining unique identification.

--- a/comid/psa/profiles.go
+++ b/comid/psa/profiles.go
@@ -1,0 +1,30 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package psa
+
+import (
+	"github.com/veraison/eat"
+)
+
+var (
+	// PSA Token Profile ID using tag URI scheme
+	TokenProfileID *eat.Profile
+
+	// PSA Platform Endorsements Profile ID using tag URI scheme 
+	EndorsementsProfileID *eat.Profile
+)
+
+func init() {
+	var err error
+
+	TokenProfileID, err = eat.NewProfile("tag:trustedcomputinggroup.org,2025:psa-token")
+	if err != nil {
+		panic(err)
+	}
+
+	EndorsementsProfileID, err = eat.NewProfile("tag:trustedcomputinggroup.org,2025:psa-endorsements") 
+	if err != nil {
+		panic(err)
+	}
+}

--- a/comid/psa/profiles_test.go
+++ b/comid/psa/profiles_test.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package psa
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/eat"
+)
+
+func TestPSAProfiles_URIFormat(t *testing.T) {
+	// Verify Token Profile ID
+	assert.Equal(t, 
+		"tag:trustedcomputinggroup.org,2025:psa-token",
+		TokenProfileID.String(),
+		"TokenProfileID should use tag URI scheme",
+	)
+
+	// Verify Endorsements Profile ID
+	assert.Equal(t,
+		"tag:trustedcomputinggroup.org,2025:psa-endorsements",
+		EndorsementsProfileID.String(), 
+		"EndorsementsProfileID should use tag URI scheme",
+	)
+}
+
+func TestPSAProfiles_Validation(t *testing.T) {
+	// Test valid tag URIs can be created
+	tests := []struct {
+		name string
+		uri string
+	}{
+		{
+			name: "Token Profile",
+			uri: "tag:trustedcomputinggroup.org,2025:psa-token",
+		},
+		{
+			name: "Endorsements Profile",
+			uri: "tag:trustedcomputinggroup.org,2025:psa-endorsements",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := eat.NewProfile(tt.uri)
+			require.NoError(t, err)
+			require.NotNil(t, profile)
+			assert.Equal(t, tt.uri, profile.String())
+		})
+	}
+}
+
+func TestPSAProfiles_InvalidURIs(t *testing.T) {
+	// Test invalid URIs are rejected
+	tests := []struct {
+		name string
+		uri string
+	}{
+		{
+			name: "HTTP URL instead of tag URI",
+			uri: "http://trustedcomputinggroup.org/psa-token",
+		},
+		{
+			name: "Missing date",
+			uri: "tag:trustedcomputinggroup.org:psa-token",
+		},
+		{
+			name: "Invalid date",
+			uri: "tag:trustedcomputinggroup.org,abcd:psa-token",
+		},
+		{
+			name: "Empty specific part",
+			uri: "tag:trustedcomputinggroup.org,2025:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			profile, err := eat.NewProfile(tt.uri)
+			if err == nil {
+				t.Errorf("Expected error for invalid URI %q, got nil", tt.uri)
+			}
+			assert.Nil(t, profile)
+		})
+	}
+}
+
+func TestPSAProfiles_Equality(t *testing.T) {
+	// Test profile equality
+	token1, err := eat.NewProfile("tag:trustedcomputinggroup.org,2025:psa-token")
+	require.NoError(t, err)
+	token2, err := eat.NewProfile("tag:trustedcomputinggroup.org,2025:psa-token")
+	require.NoError(t, err)
+	endorsements, err := eat.NewProfile("tag:trustedcomputinggroup.org,2025:psa-endorsements")
+	require.NoError(t, err)
+
+	// Same profile URIs should be equal
+	assert.Equal(t, token1, token2)
+
+	// Different profile URIs should not be equal
+	assert.NotEqual(t, token1, endorsements)
+}


### PR DESCRIPTION
Changed profile identifiers from HTTP URLs to tag URIs (RFC 4151)
PSA profiles now use tag:trustedcomputinggroup.org,2025 authority
CCA profiles now use tag:arm.com,2025 authority
Added comprehensive test coverage for URI validation
Added package documentation with usage examples 

Fixes #110 