### PR TITLE
Implement CCA-Specific Tagged Values for Reference Values and Class Variables

### DIFF
--- a/comid/ccaimplementationid.go
+++ b/comid/ccaimplementationid.go
@@ -1,0 +1,144 @@
+// Copyright 2021-2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package comid
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// CCA class type identifier
+var CCAImplIDType = "cca.impl-id"
+
+type CCAImplID [32]byte
+
+func (o CCAImplID) String() string {
+	return base64.StdEncoding.EncodeToString(o[:])
+}
+
+// how do we validate  cca id beyond lenght check?
+func (o CCAImplID) Valid() error {
+	return nil
+}
+
+// A CCAImplID with CBOR tagging
+type TaggedCCAImplID CCAImplID
+
+// Creates a new ClassID with a CCA Implementation ID value
+func NewCCAImplIDClassID(val any) (*ClassID, error) {
+	var ret TaggedCCAImplID
+
+	if val == nil {
+		return &ClassID{&TaggedCCAImplID{}}, nil
+	}
+
+	switch t := val.(type) {
+	case []byte:
+		if nb := len(t); nb != 32 {
+			return nil, fmt.Errorf("bad cca.impl-id: got %d bytes, want 32", nb)
+		}
+
+		copy(ret[:], t)
+	case string:
+		v, err := base64.StdEncoding.DecodeString(t)
+		if err != nil {
+			return nil, fmt.Errorf("bad cca.impl-id: %w", err)
+		}
+
+		if nb := len(v); nb != 32 {
+			return nil, fmt.Errorf("bad cca.impl-id: decoded %d bytes, want 32", nb)
+		}
+
+		copy(ret[:], v)
+	case TaggedCCAImplID:
+		copy(ret[:], t[:])
+	case *TaggedCCAImplID:
+		copy(ret[:], (*t)[:])
+	case CCAImplID:
+		copy(ret[:], t[:])
+	case *CCAImplID:
+		copy(ret[:], (*t)[:])
+	default:
+		return nil, fmt.Errorf("unexpected type for cca.impl-id: %T", t)
+	}
+
+	return &ClassID{&ret}, nil
+}
+
+// like above method but panics on error
+func MustNewCCAImplIDClassID(val any) *ClassID {
+	ret, err := NewCCAImplIDClassID(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
+func (o TaggedCCAImplID) Valid() error {
+	return CCAImplID(o).Valid()
+}
+
+func (o TaggedCCAImplID) String() string {
+	return CCAImplID(o).String()
+}
+
+func (o TaggedCCAImplID) Type() string {
+	return CCAImplIDType
+}
+
+func (o TaggedCCAImplID) Bytes() []byte {
+	return o[:]
+}
+
+func (o TaggedCCAImplID) MarshalJSON() ([]byte, error) {
+	return json.Marshal((o)[:])
+}
+
+func (o *TaggedCCAImplID) UnmarshalJSON(data []byte) error {
+	var out []byte
+	if err := json.Unmarshal(data, &out); err != nil {
+		return err
+	}
+
+	if len(out) != 32 {
+		return fmt.Errorf("bad cca.impl-id: decoded %d bytes, want 32", len(out))
+	}
+
+	copy((*o)[:], out)
+
+	return nil
+}
+
+func NewCCAImplID(id [32]byte) CCAImplID {
+	return CCAImplID(id)
+}
+
+func (o *ClassID) SetCCAImplID(implID CCAImplID) *ClassID {
+	if o != nil {
+		o.Value = TaggedCCAImplID(implID)
+	}
+	return o
+}
+
+func (o ClassID) GetCCAImplID() (CCAImplID, error) {
+	switch t := o.Value.(type) {
+	case *TaggedCCAImplID:
+		return CCAImplID(*t), nil
+	case TaggedCCAImplID:
+		return CCAImplID(t), nil
+	default:
+		return CCAImplID{}, fmt.Errorf("class-id type is: %T", t)
+	}
+}
+
+func NewClassCCAImplID(implID CCAImplID) *ClassID {
+	return new(ClassID).SetCCAImplID(implID)
+}
+
+func init() {
+	// Register the CCA Implementation ID type
+	classIDValueRegister[CCAImplIDType] = NewCCAImplIDClassID
+}

--- a/comid/ccaimplementationid_test.go
+++ b/comid/ccaimplementationid_test.go
@@ -1,0 +1,168 @@
+// Copyright 2021-2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package comid
+
+import (
+    "encoding/base64"
+    "encoding/json"
+    "testing"
+
+    "github.com/stretchr/testify/assert"
+    "github.com/stretchr/testify/require"
+)
+
+var TestCCAImplID = CCAImplID{
+    0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+    0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+    0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+    0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+func TestCCAImplID_Valid(t *testing.T) {
+    implID := TestCCAImplID
+    err := implID.Valid()
+    assert.NoError(t, err)
+}
+
+func TestCCAImplID_String(t *testing.T) {
+    implID := TestCCAImplID
+    expected := base64.StdEncoding.EncodeToString(implID[:])
+    assert.Equal(t, expected, implID.String())
+}
+
+func TestTaggedCCAImplID_Valid(t *testing.T) {
+    var implID TaggedCCAImplID
+    copy(implID[:], TestCCAImplID[:])
+    err := implID.Valid()
+    assert.NoError(t, err)
+}
+
+func TestTaggedCCAImplID_Type(t *testing.T) {
+    var implID TaggedCCAImplID
+    assert.Equal(t, CCAImplIDType, implID.Type())
+}
+
+func TestTaggedCCAImplID_String(t *testing.T) {
+    var implID TaggedCCAImplID
+    copy(implID[:], TestCCAImplID[:])
+    expected := base64.StdEncoding.EncodeToString(implID[:])
+    assert.Equal(t, expected, implID.String())
+}
+
+func TestNewCCAImplIDClassID(t *testing.T) {
+    // Test with nil
+    classID, err := NewCCAImplIDClassID(nil)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+    
+    // Test with byte array
+    classID, err = NewCCAImplIDClassID(TestCCAImplID[:])
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with base64 string
+    base64Str := base64.StdEncoding.EncodeToString(TestCCAImplID[:])
+    classID, err = NewCCAImplIDClassID(base64Str)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with CCAImplID
+    classID, err = NewCCAImplIDClassID(TestCCAImplID)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with TaggedCCAImplID
+    var taggedID TaggedCCAImplID
+    copy(taggedID[:], TestCCAImplID[:])
+    classID, err = NewCCAImplIDClassID(taggedID)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with pointer to TaggedCCAImplID
+    classID, err = NewCCAImplIDClassID(&taggedID)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with pointer to CCAImplID
+    ptr := &TestCCAImplID
+    classID, err = NewCCAImplIDClassID(ptr)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    // Test with invalid length
+    _, err = NewCCAImplIDClassID([]byte{0x01, 0x02, 0x03})
+    assert.Error(t, err)
+
+    // Test with invalid type
+    _, err = NewCCAImplIDClassID(123)
+    assert.Error(t, err)
+}
+
+func TestMustNewCCAImplIDClassID(t *testing.T) {
+    classID := MustNewCCAImplIDClassID(TestCCAImplID)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+
+    assert.Panics(t, func() {
+        MustNewCCAImplIDClassID([]byte{0x01, 0x02, 0x03})
+    })
+}
+
+func TestClassID_SetGetCCAImplID(t *testing.T) {
+    classID := new(ClassID).SetCCAImplID(TestCCAImplID)
+    
+    implID, err := classID.GetCCAImplID()
+    require.NoError(t, err)
+    assert.Equal(t, TestCCAImplID, implID)
+
+    // Test with wrong type
+    classID, err = NewClassID(TestUUID, UUIDType)
+    _, err = classID.GetCCAImplID()
+    assert.Error(t, err)
+}
+
+func TestNewClassCCAImplID(t *testing.T) {
+    classID := NewClassCCAImplID(TestCCAImplID)
+    
+    implID, err := classID.GetCCAImplID()
+    require.NoError(t, err)
+    assert.Equal(t, TestCCAImplID, implID)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+}
+
+func TestTaggedCCAImplID_JSON(t *testing.T) {
+    var implID TaggedCCAImplID
+    copy(implID[:], TestCCAImplID[:])
+
+    // Test marshaling
+    bytes, err := json.Marshal(implID)
+    require.NoError(t, err)
+
+    // Test unmarshaling
+    var unmarshalledID TaggedCCAImplID
+    err = json.Unmarshal(bytes, &unmarshalledID)
+    require.NoError(t, err)
+
+    assert.Equal(t, implID, unmarshalledID)
+
+    // Test unmarshaling with invalid data
+    invalidData := []byte(`"not valid base64"`)
+    err = json.Unmarshal(invalidData, &unmarshalledID)
+    assert.Error(t, err)
+
+    // Test unmarshaling with invalid length
+    shortData := []byte(`[1,2,3]`)
+    err = json.Unmarshal(shortData, &unmarshalledID)
+    assert.Error(t, err)
+}
+
+func TestCCAImplIDClassIDRegistration(t *testing.T) {
+    factory, ok := classIDValueRegister[CCAImplIDType]
+    assert.True(t, ok, "CCA Impl ID type should be registered")
+    assert.NotNil(t, factory, "Factory function should not be nil")
+    
+    // Test the factory function
+    classID, err := factory(TestCCAImplID)
+    require.NoError(t, err)
+    assert.Equal(t, CCAImplIDType, classID.Type())
+}

--- a/comid/ccareferencevalue.go
+++ b/comid/ccareferencevalue.go
@@ -1,0 +1,152 @@
+// Copyright 2021-2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package comid
+
+import (
+    "encoding/json"
+    "errors"
+    "fmt"
+)
+
+var CCARefValIDType = "cca.refval-id"
+
+type CCARefValID struct {
+    Label    *string `cbor:"1,keyasint,omitempty" json:"label,omitempty"`
+    Version  *string `cbor:"4,keyasint,omitempty" json:"version,omitempty"`
+    SignerID []byte  `cbor:"5,keyasint" json:"signer-id"` 
+}
+
+func (o CCARefValID) Valid() error {
+    if o.SignerID == nil {
+        return errors.New("missing mandatory signer ID")
+    }
+
+    switch len(o.SignerID) {
+    case 32, 48, 64:
+        // Valid lengths
+    default:
+        return fmt.Errorf("want 32, 48 or 64 bytes, got %d", len(o.SignerID))
+    }
+
+    return nil
+}
+
+func CreateCCARefValID(signerID []byte, label, version string) (*CCARefValID, error) {
+    ret, err := NewCCARefValID(signerID)
+    if err != nil {
+        return nil, err
+    }
+
+    ret.SetLabel(label)
+    ret.SetVersion(version)
+
+    return ret, nil
+}
+
+// MustCreateCCARefValID is like CreateCCARefValID but panics on error
+func MustCreateCCARefValID(signerID []byte, label, version string) *CCARefValID {
+    ret, err := CreateCCARefValID(signerID, label, version)
+
+    if err != nil {
+        panic(err)
+    }
+
+    return ret
+}
+
+func NewCCARefValID(val any) (*CCARefValID, error) {
+    var ret CCARefValID
+
+    if val == nil {
+        return &ret, nil
+    }
+
+    switch t := val.(type) {
+    case CCARefValID:
+        ret = t
+    case *CCARefValID:
+        ret = *t
+    case string:
+        if err := json.Unmarshal([]byte(t), &ret); err != nil {
+            return nil, err
+        }
+    case []byte:
+        switch len(t) {
+        case 32, 48, 64:
+            ret.SignerID = t
+        default:
+            return nil, fmt.Errorf("invalid CCA RefVal ID length: %d", len(t))
+        }
+    default:
+        return nil, fmt.Errorf("unexpected type for CCA RefVal ID: %T", t)
+    }
+
+    return &ret, nil
+}
+
+func (o *CCARefValID) SetLabel(label string) *CCARefValID {
+    if o != nil {
+        o.Label = &label
+    }
+    return o
+}
+
+func (o *CCARefValID) SetVersion(version string) *CCARefValID {
+    if o != nil {
+        o.Version = &version
+    }
+    return o
+}
+
+type TaggedCCARefValID CCARefValID
+
+func NewTaggedCCARefValID(val any) (*TaggedCCARefValID, error) {
+    var ret TaggedCCARefValID
+
+    switch t := val.(type) {
+    case TaggedCCARefValID:
+        ret = t
+    case *TaggedCCARefValID:
+        ret = *t
+    default:
+        refvalID, err := NewCCARefValID(val)
+        if err != nil {
+            return nil, err
+        }
+        ret = TaggedCCARefValID(*refvalID)
+    }
+
+    return &ret, nil
+}
+
+func (o TaggedCCARefValID) Valid() error {
+    return CCARefValID(o).Valid()
+}
+
+func (o TaggedCCARefValID) String() string {
+    ret, err := json.Marshal(o)
+    if err != nil {
+        return ""
+    }
+
+    return string(ret)
+}
+
+func (o TaggedCCARefValID) Type() string {
+    return CCARefValIDType
+}
+
+func (o TaggedCCARefValID) IsZero() bool {
+    return len(o.SignerID) == 0
+}
+
+func NewMkeyCCARefValID(val any) (*Mkey, error) {
+    ret, err := NewTaggedCCARefValID(val)
+    if err != nil {
+        return nil, err
+    }
+
+    return &Mkey{ret}, nil
+}
+

--- a/comid/ccareferencevalue_test.go
+++ b/comid/ccareferencevalue_test.go
@@ -1,0 +1,303 @@
+// Copyright 2021-2024 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package comid
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/veraison/swid"
+)
+
+var TestCCASignerID = []byte{
+	0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08,
+	0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10,
+	0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18,
+	0x19, 0x1a, 0x1b, 0x1c, 0x1d, 0x1e, 0x1f, 0x20,
+}
+
+func TestCCARefValID_Valid(t *testing.T) {
+	// Valid case with 32 bytes
+	refValID := &CCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	err := refValID.Valid()
+	assert.NoError(t, err)
+
+	// Valid case with 48 bytes
+	refValID = &CCARefValID{
+		SignerID: make([]byte, 48),
+	}
+	err = refValID.Valid()
+	assert.NoError(t, err)
+
+	// Valid case with 64 bytes
+	refValID = &CCARefValID{
+		SignerID: make([]byte, 64),
+	}
+	err = refValID.Valid()
+	assert.NoError(t, err)
+
+	// Invalid case with nil SignerID
+	refValID = &CCARefValID{
+		SignerID: nil,
+	}
+	err = refValID.Valid()
+	assert.Error(t, err)
+
+	// Invalid case with wrong length
+	refValID = &CCARefValID{
+		SignerID: []byte{0x01, 0x02, 0x03},
+	}
+	err = refValID.Valid()
+	assert.Error(t, err)
+}
+
+func TestNewCCARefValID(t *testing.T) {
+	// Test with nil
+	refValID, err := NewCCARefValID(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, refValID)
+
+	// Test with CCARefValID
+	original := &CCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	label := "Label"
+	version := "1.0.0"
+	original.SetLabel(label)
+	original.SetVersion(version)
+
+	refValID, err = NewCCARefValID(*original)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, refValID.SignerID)
+	assert.Equal(t, &label, refValID.Label)
+	assert.Equal(t, &version, refValID.Version)
+
+	// Test with pointer to CCARefValID
+	refValID, err = NewCCARefValID(original)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, refValID.SignerID)
+
+	// Test with byte array (signer ID)
+	refValID, err = NewCCARefValID(TestCCASignerID)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, refValID.SignerID)
+
+	// Test with byte array of invalid length
+	_, err = NewCCARefValID([]byte{0x01, 0x02})
+	assert.Error(t, err)
+
+	// Test with invalid type
+	_, err = NewCCARefValID(123)
+	assert.Error(t, err)
+}
+
+func TestCreateCCARefValID(t *testing.T) {
+	label := "CCA-BL"
+	version := "1.0.0"
+
+	refValID, err := CreateCCARefValID(TestCCASignerID, label, version)
+	require.NoError(t, err)
+
+	assert.Equal(t, TestCCASignerID, refValID.SignerID)
+	assert.Equal(t, &label, refValID.Label)
+	assert.Equal(t, &version, refValID.Version)
+
+	// Invalid signer ID
+	_, err = CreateCCARefValID([]byte{0x01}, label, version)
+	assert.Error(t, err)
+}
+
+func TestMustCreateCCARefValID(t *testing.T) {
+	label := "CCA-BL"
+	version := "1.0.0"
+
+	refValID := MustCreateCCARefValID(TestCCASignerID, label, version)
+	assert.Equal(t, TestCCASignerID, refValID.SignerID)
+	assert.Equal(t, &label, refValID.Label)
+	assert.Equal(t, &version, refValID.Version)
+
+	// Should panic with invalid signer ID
+	assert.Panics(t, func() {
+		MustCreateCCARefValID([]byte{0x01}, label, version)
+	})
+}
+
+func TestCCARefValID_SetLabel(t *testing.T) {
+	refValID := &CCARefValID{}
+	label := "CCA-BL"
+
+	refValID.SetLabel(label)
+	assert.Equal(t, &label, refValID.Label)
+}
+
+func TestCCARefValID_SetVersion(t *testing.T) {
+	refValID := &CCARefValID{}
+	version := "1.0.0"
+
+	refValID.SetVersion(version)
+	assert.Equal(t, &version, refValID.Version)
+}
+
+func TestTaggedCCARefValID(t *testing.T) {
+	// Test Type()
+	var tagged TaggedCCARefValID
+	assert.Equal(t, CCARefValIDType, tagged.Type())
+
+	// Test Valid()
+	tagged = TaggedCCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	err := tagged.Valid()
+	assert.NoError(t, err)
+
+	tagged = TaggedCCARefValID{
+		SignerID: nil,
+	}
+	err = tagged.Valid()
+	assert.Error(t, err)
+
+	// Test String()
+	tagged = TaggedCCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	str := tagged.String()
+	assert.NotEmpty(t, str)
+
+	// Test IsZero()
+	tagged = TaggedCCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	assert.False(t, tagged.IsZero())
+
+	tagged = TaggedCCARefValID{
+		SignerID: nil,
+	}
+	assert.True(t, tagged.IsZero())
+}
+
+func TestNewTaggedCCARefValID(t *testing.T) {
+	// Test with nil
+	tagged, err := NewTaggedCCARefValID(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, tagged)
+
+	// Test with CCARefValID
+	refValID := &CCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	tagged, err = NewTaggedCCARefValID(refValID)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, tagged.SignerID)
+
+	// Test with TaggedCCARefValID
+	original := TaggedCCARefValID{
+		SignerID: TestCCASignerID,
+	}
+	tagged, err = NewTaggedCCARefValID(original)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, tagged.SignerID)
+
+	// Test with pointer to TaggedCCARefValID
+	tagged, err = NewTaggedCCARefValID(&original)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, tagged.SignerID)
+
+	// Test with byte array (signer ID)
+	tagged, err = NewTaggedCCARefValID(TestCCASignerID)
+	require.NoError(t, err)
+	assert.Equal(t, TestCCASignerID, tagged.SignerID)
+
+	// Test with byte array of invalid length
+	_, err = NewTaggedCCARefValID([]byte{0x01, 0x02})
+	assert.Error(t, err)
+}
+
+func TestNewMkeyCCARefValID(t *testing.T) {
+	refValID := &CCARefValID{
+		SignerID: TestCCASignerID,
+	}
+
+	mkey, err := NewMkeyCCARefValID(refValID)
+	require.NoError(t, err)
+
+	assert.Equal(t, CCARefValIDType, mkey.Type())
+	assert.True(t, mkey.IsSet())
+
+	// Test with invalid input
+	_, err = NewMkeyCCARefValID([]byte{0x01, 0x02})
+	assert.Error(t, err)
+}
+
+func TestCCARefValID_JSON(t *testing.T) {
+	// Create a test CCARefValID
+	label := "CCA-BL"
+	version := "1.0.0"
+	refValID := MustCreateCCARefValID(TestCCASignerID, label, version)
+
+	// Marshal to JSON
+	data, err := json.Marshal(refValID)
+	require.NoError(t, err)
+
+	// Unmarshal from JSON
+	var unmarshalled CCARefValID
+	err = json.Unmarshal(data, &unmarshalled)
+	require.NoError(t, err)
+
+	// Check values
+	assert.Equal(t, label, *unmarshalled.Label)
+	assert.Equal(t, version, *unmarshalled.Version)
+	assert.Equal(t, TestCCASignerID, unmarshalled.SignerID)
+}
+
+func TestCCAMeasurement(t *testing.T) {
+	// Test NewCCAMeasurement
+	refValID := MustCreateCCARefValID(TestCCASignerID, "CCA-BL", "1.0.0")
+
+	measurement, err := NewCCAMeasurement(refValID)
+	require.NoError(t, err)
+
+	assert.Equal(t, CCARefValIDType, measurement.Key.Type())
+
+	// Test MustNewCCAMeasurement
+	measurement = MustNewCCAMeasurement(refValID)
+	assert.Equal(t, CCARefValIDType, measurement.Key.Type())
+
+	// Test MustNewCCAMeasurement with invalid input
+	invalidRefValID := &CCARefValID{
+		SignerID: []byte{0x01, 0x02}, // Invalid length
+	}
+	assert.Panics(t, func() {
+		MustNewCCAMeasurement(invalidRefValID)
+	})
+}
+
+func TestCCARefValIDRegistration(t *testing.T) {
+	// Check if CCARefValIDType is registered in mkeyValueRegister
+	factory, ok := mkeyValueRegister[CCARefValIDType]
+	assert.True(t, ok, "CCA RefVal ID type should be registered")
+	assert.NotNil(t, factory, "Factory function should not be nil")
+
+	// Test the factory function
+	refValID := MustCreateCCARefValID(TestCCASignerID, "CCA-BL", "1.0.0")
+	mkey, err := factory(refValID)
+	require.NoError(t, err)
+	assert.Equal(t, CCARefValIDType, mkey.Type())
+}
+
+func TestCCARefValInMeasurement(t *testing.T) {
+	refValID := MustCreateCCARefValID(TestCCASignerID, "CCA-BL", "1.0.0")
+
+	measurement := MustNewCCAMeasurement(refValID)
+
+	digest := []byte{0xaa, 0xbb, 0xcc, 0xdd}
+	measurement.AddDigest(swid.Sha256, digest)
+
+	// Validate the measurement
+	err := measurement.Valid()
+	assert.NoError(t, err)
+}

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -315,6 +315,7 @@ var mkeyValueRegister = map[string]IMkeyFactory{
 	UintType:                NewMkeyUint,
 	PSARefValIDType:         NewMkeyPSARefvalID,
 	CCAPlatformConfigIDType: NewMkeyCCAPlatformConfigID,
+	CCARefValIDType:         NewMkeyCCARefValID,
 }
 
 // RegisterMkeyType registers a new IMKeyValue implementation
@@ -542,6 +543,27 @@ func MustNewPSAMeasurement(key any) *Measurement {
 		panic(err)
 	}
 
+	return ret
+}
+
+func NewCCAMeasurement(key any) (*Measurement, error) {
+	m, err := NewMeasurement(key, CCARefValIDType)
+	if err != nil {
+		return nil, err
+	}
+
+	if m.Val.Digests == nil {
+		m.Val.Digests = NewDigests()
+	}
+
+	return m, nil
+}
+
+func MustNewCCAMeasurement(key any) *Measurement {
+	ret, err := NewCCAMeasurement(key)
+	if err != nil {
+		panic(err)
+	}
 	return ret
 }
 


### PR DESCRIPTION
Signed-off-by: Vaidik Bhardwaj <vaidikbhardwaj00@gmail.com>

I have implemented the CCA class ID and reference value ID. Both implementations are inspired by the PSA approach. I'm not sure if there’s a different way to achieve this. I have also written new tests, and they all pass. I would appreciate feedback on whether there might be another way to implement CCA identifiers.

Fixes #73 