### PR TITLE
feat: add CoTS support to CoSERV (#201)

### DIFF
--- a/coserv/quads.go
+++ b/coserv/quads.go
@@ -19,6 +19,6 @@ type AKQuad struct {
 }
 
 type CoTSStmt struct {
-	Authorities *comid.CryptoKeys      `cbor:"1,keyasint"`
-	CoTS        *cots.ConciseTaStore   `cbor:"2,keyasint"`
+	Authorities *comid.CryptoKeys    `cbor:"1,keyasint"`
+	CoTS        *cots.ConciseTaStore `cbor:"2,keyasint"`
 }

--- a/coserv/quads.go
+++ b/coserv/quads.go
@@ -3,7 +3,10 @@
 
 package coserv
 
-import "github.com/veraison/corim/comid"
+import (
+	"github.com/veraison/corim/comid"
+	"github.com/veraison/corim/cots"
+)
 
 type RefValQuad struct {
 	Authorities *comid.CryptoKeys  `cbor:"1,keyasint"`
@@ -13,4 +16,9 @@ type RefValQuad struct {
 type AKQuad struct {
 	Authorities *comid.CryptoKeys `cbor:"1,keyasint"`
 	AKTriple    *comid.KeyTriple  `cbor:"2,keyasint"`
+}
+
+type CoTSStmt struct {
+	Authorities *comid.CryptoKeys      `cbor:"1,keyasint"`
+	CoTS        *cots.ConciseTaStore   `cbor:"2,keyasint"`
 }

--- a/coserv/resultset.go
+++ b/coserv/resultset.go
@@ -13,8 +13,8 @@ import (
 type ResultSet struct {
 	RVQ *[]RefValQuad `cbor:"0,keyasint,omitempty"`
 	AKQ *[]AKQuad     `cbor:"3,keyasint,omitempty"`
+	TAS *[]CoTSStmt   `cbor:"4,keyasint,omitempty"`
 	// TODO(tho) add endorsed values
-	// TODO(tho) add CoTS
 	Expiry          *time.Time `cbor:"10,keyasint"`
 	SourceArtifacts *[]cmw.CMW `cbor:"11,keyasint,omitempty"`
 }
@@ -42,6 +42,17 @@ func (o *ResultSet) AddAttestationKeys(v AKQuad) *ResultSet {
 	}
 
 	*o.AKQ = append(*o.AKQ, v)
+
+	return o
+}
+
+// AddCoTS adds the supplied CoTS statement to the target ResultSet
+func (o *ResultSet) AddCoTS(v CoTSStmt) *ResultSet {
+	if o.TAS == nil {
+		o.TAS = new([]CoTSStmt)
+	}
+
+	*o.TAS = append(*o.TAS, v)
 
 	return o
 }

--- a/coserv/resultset_test.go
+++ b/coserv/resultset_test.go
@@ -39,7 +39,7 @@ func TestResultSet_AddCoTS(t *testing.T) {
 
 	// Create a simple CoTS structure for testing
 	cotsStore := cots.NewConciseTaStore()
-	
+
 	// Add a basic environment group with a class
 	class := comid.NewClassBytes(testBytes)
 	env := comid.Environment{
@@ -48,7 +48,7 @@ func TestResultSet_AddCoTS(t *testing.T) {
 	eg := cots.EnvironmentGroup{}
 	eg.SetEnvironment(env)
 	cotsStore.AddEnvironmentGroup(eg)
-	
+
 	// Add trust anchor keys
 	testCert := []byte{0x30, 0x82, 0x01, 0x00} // Simple test cert bytes
 	tas := cots.NewTasAndCas()

--- a/coserv/resultset_test.go
+++ b/coserv/resultset_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/veraison/cmw"
 	"github.com/veraison/corim/comid"
+	"github.com/veraison/corim/cots"
 )
 
 func TestResultSet_AddAttestationKeys(t *testing.T) {
@@ -30,6 +31,39 @@ func TestResultSet_AddAttestationKeys(t *testing.T) {
 
 	rset := NewResultSet().SetExpiry(testExpiry).AddAttestationKeys(akq)
 	assert.NotNil(t, rset)
+}
+
+func TestResultSet_AddCoTS(t *testing.T) {
+	authority, err := comid.NewCryptoKeyTaggedBytes(testAuthority)
+	require.NoError(t, err)
+
+	// Create a simple CoTS structure for testing
+	cotsStore := cots.NewConciseTaStore()
+	
+	// Add a basic environment group with a class
+	class := comid.NewClassBytes(testBytes)
+	env := comid.Environment{
+		Class: class,
+	}
+	eg := cots.EnvironmentGroup{}
+	eg.SetEnvironment(env)
+	cotsStore.AddEnvironmentGroup(eg)
+	
+	// Add trust anchor keys
+	testCert := []byte{0x30, 0x82, 0x01, 0x00} // Simple test cert bytes
+	tas := cots.NewTasAndCas()
+	tas.AddTaCert(testCert)
+	cotsStore.SetKeys(*tas)
+
+	cotsStmt := CoTSStmt{
+		Authorities: comid.NewCryptoKeys().Add(authority),
+		CoTS:        cotsStore,
+	}
+
+	rset := NewResultSet().SetExpiry(testExpiry).AddCoTS(cotsStmt)
+	assert.NotNil(t, rset)
+	assert.NotNil(t, rset.TAS)
+	assert.Equal(t, 1, len(*rset.TAS))
 }
 
 func TestResultSet_AddSourceArtifacts(t *testing.T) {


### PR DESCRIPTION
### Implements support for CoTS (Concise Trust Anchor Store) in the CoSERV package as specified in draft-howard-rats-coserv-02.

**Changes**:
- Added CoTSStmt struct to quads.go with authorities and CoTS fields
- Updated ResultSet to include TAS field (CBOR field 4) for CoTS statements
- Implemented AddCoTS() method to allow adding CoTS statements to ResultSet
- Added comprehensive unit tests for CoTS functionality
- Removed TODO comment for CoTS in resultset.go

This implementation follows the CoSERV specification trust-anchors structure:
```
  trust-anchors = (
    &(akq: 3) => [ * ak-quad ]
    &(tas: 4) => [ * cots-stmt ]
  )
```

Fixes #201