### PR TITLE
feat(comid): add string Mkey support

### DIFF
--- a/comid/measurement_test.go
+++ b/comid/measurement_test.go
@@ -334,7 +334,7 @@ func TestMkey_UnmarshalCBOR_not_ok(t *testing.T) {
 	}{
 		{
 			input:    []byte{0xAB, 0xCD},
-			expected: "unexpected EOF",
+			expected: "unexpected CBOR major type for mkey: 5",
 		},
 		{
 			input:    []byte{0xCC, 0xDD, 0xFF},
@@ -516,6 +516,99 @@ func TestNewUintMkey(t *testing.T) {
 		} else {
 			assert.Equal(t, tv.expected, *out)
 		}
+	}
+}
+
+func TestNewStringMkey(t *testing.T) {
+	testString := "foo"
+	testBytes := MustHexDecode(t, "666f6f")
+	testBytesBad := MustHexDecode(t, "ff")
+	testVal := StringMkey(testString)
+
+	tvs := []struct {
+		input    any
+		expected StringMkey
+		err      string
+	}{
+		{
+			input:    testString,
+			expected: testVal,
+		},
+		{
+			input:    &testString,
+			expected: testVal,
+		},
+		{
+			input:    testBytes,
+			expected: testVal,
+		},
+		{
+			input:    &testBytes,
+			expected: testVal,
+		},
+		{
+			input:    testVal,
+			expected: testVal,
+		},
+		{
+			input:    &testVal,
+			expected: testVal,
+		},
+		{
+			input: testBytesBad,
+			err:   "invalid utf-8 string: ff",
+		},
+		{
+			input: &testBytesBad,
+			err:   "invalid utf-8 string: ff",
+		},
+		{
+			input: 7,
+			err:   "unexpected type for StringMkey: int",
+		},
+	}
+
+	for _, tv := range tvs {
+		out, err := NewStringMkey(tv.input)
+		if tv.err != "" {
+			assert.Nil(t, out)
+			assert.EqualError(t, err, tv.err)
+		} else {
+			assert.Equal(t, tv.expected, *out)
+		}
+	}
+}
+
+func TestMKey_string_marshaling_round_trip(t *testing.T) {
+	tvs := []struct {
+		input         *Mkey
+		expected_json []byte
+		expected_cbor []byte
+	}{
+		{
+			input:         MustNewMkey("foo", "string"),
+			expected_json: []byte(`{"type":"string","value":"foo"}`),
+			expected_cbor: MustHexDecode(t, "63666f6f"),
+		},
+	}
+
+	for _, tv := range tvs {
+		actual_json, err := tv.input.MarshalJSON()
+		assert.Nil(t, err)
+		assert.Equal(t, tv.expected_json, actual_json)
+
+		var key Mkey
+		err = key.UnmarshalJSON(actual_json)
+		assert.Nil(t, err)
+		assert.Equal(t, tv.input, &key)
+
+		actual_cbor, err := tv.input.MarshalCBOR()
+		assert.Nil(t, err)
+		assert.Equal(t, tv.expected_cbor, actual_cbor)
+
+		err = key.UnmarshalCBOR(actual_cbor)
+		assert.Nil(t, err)
+		assert.Equal(t, tv.input, &key)
 	}
 }
 


### PR DESCRIPTION
Since rev. 6, CoRIM spec expanded $measured-element-type-choice with tstr variant. Thus updates the corresponding Mkey type to support the new StringMkey variant.