### PR TITLE
fix: use NewEntities() for entity collection construction

### DIFF
--- a/comid/comid.go
+++ b/comid/comid.go
@@ -146,7 +146,7 @@ func (o *Comid) AddEntity(name string, regID *string, roles ...Role) *Comid {
 		}
 
 		if o.Entities == nil {
-			o.Entities = new(Entities)
+			o.Entities = NewEntities()
 		}
 
 		if o.Entities.Add(&e) == nil {

--- a/corim/unsignedcorim.go
+++ b/corim/unsignedcorim.go
@@ -219,7 +219,7 @@ func (o *UnsignedCorim) AddEntity(name string, regID *string, roles ...Role) *Un
 		}
 
 		if o.Entities == nil {
-			o.Entities = new(Entities)
+			o.Entities = NewEntities()
 		}
 
 		if o.Entities.Add(e) == nil {

--- a/corim/unsignedcorim_test.go
+++ b/corim/unsignedcorim_test.go
@@ -257,15 +257,11 @@ func TestUnsignedCorim_AddEntity_full(t *testing.T) {
 		AddEntity(name, &regID, role)
 
 	expected := UnsignedCorim{
-		Entities: &Entities{
-			Values: []Entity{
-				{
-					Name:  MustNewStringEntityName(name),
-					Roles: Roles{role},
-					RegID: &taggedRegID,
-				},
-			},
-		},
+		Entities: NewEntities().Add(&Entity{
+			Name:  MustNewStringEntityName(name),
+			Roles: Roles{role},
+			RegID: &taggedRegID,
+		}),
 	}
 
 	assert.NotNil(t, actual)


### PR DESCRIPTION
Use NewEntities() to instantiate entity collections to make sure the collections' internal structures are properly initialized on creation.