### PR TITLE
fix: allow indefinite length when decoding

### DIFF
--- a/coev/cbor.go
+++ b/coev/cbor.go
@@ -47,7 +47,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(coevTags())
 }

--- a/comid/cbor.go
+++ b/comid/cbor.go
@@ -67,7 +67,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(comidTags())
 }

--- a/comid/tdx/cbor.go
+++ b/comid/tdx/cbor.go
@@ -49,7 +49,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecModeWithTags(tdxTags())
 }

--- a/corim/cbor.go
+++ b/corim/cbor.go
@@ -53,7 +53,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.DecTagRequired,
 	}
 	return decOpt.DecModeWithTags(corimTags())

--- a/cots/cbor.go
+++ b/cots/cbor.go
@@ -50,7 +50,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 		TimeTag:     cbor.DecTagRequired,
 	}
 	return decOpt.DecModeWithTags(cotsTags())

--- a/extensions/cbor.go
+++ b/extensions/cbor.go
@@ -23,7 +23,7 @@ func initCBOREncMode() (en cbor.EncMode, err error) {
 
 func initCBORDecMode() (dm cbor.DecMode, err error) {
 	decOpt := cbor.DecOptions{
-		IndefLength: cbor.IndefLengthForbidden,
+		IndefLength: cbor.IndefLengthAllowed,
 	}
 	return decOpt.DecMode()
 }


### PR DESCRIPTION
The CoRIM specification does not specify any restrictions on the CBOR encoding, so indefinite length structures are valid.

Since CoSERV _does_ require deterministic (and therefore, definite length) encoding, keep the existing restriction on encoding.

This is anlternative to https://github.com/veraison/corim/pull/222 that does not touch the encoding path.

Addresses https://github.com/veraison/corim/issues/211.