### PR TITLE
feat(comid): add Must versions of bytes ID constructors

### DIFF
--- a/comid/classid.go
+++ b/comid/classid.go
@@ -448,6 +448,18 @@ func (o TaggedInt) Bytes() []byte {
 	return ret[:]
 }
 
+// MustNewBytesClassID is like NewBytesClassID except it does not return an
+// error, assuming that the provided value is valid. It panics if that isn't
+// the case.
+func MustNewBytesClassID(val any) *ClassID {
+	ret, err := NewBytesClassID(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
 // NewBytesClassID creates a New ClassID of type bytes
 // The supplied interface parameter could be
 // a byte slice, a pointer to a byte slice or a string

--- a/comid/classid_test.go
+++ b/comid/classid_test.go
@@ -577,6 +577,11 @@ func Test_NewBytesClassID_NOK(t *testing.T) {
 	}
 }
 
+func Test_MustNewBytesClassID(t *testing.T) {
+	MustNewBytesClassID([]byte{0x01, 0x02, 0x03, 0x04})
+	assert.Panics(t, func() { MustNewBytesClassID(7) })
+}
+
 func TestClassID_MarshalCBOR_Bytes(t *testing.T) {
 	tv, err := NewBytesClassID(TestBytes)
 	require.NoError(t, err)

--- a/comid/group.go
+++ b/comid/group.go
@@ -146,6 +146,18 @@ func MustNewUUIDGroup(val any) *Group {
 	return ret
 }
 
+// MustNewBytesGroup is like NewBytesGroup except it does not return an
+// error, assuming that the provided value is valid. It panics if that isn't
+// the case.
+func MustNewBytesGroup(val any) *Group {
+	ret, err := NewBytesGroup(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
 // NewBytesGroup creates a New Group of type bytes
 // The supplied interface parameter could be
 // a byte slice, a pointer to a byte slice or a string

--- a/comid/group_test.go
+++ b/comid/group_test.go
@@ -110,6 +110,11 @@ func Test_NewBytesGroup_NOK(t *testing.T) {
 	}
 }
 
+func Test_MustNewBytesGroup(t *testing.T) {
+	MustNewBytesGroup([]byte{0x01, 0x02, 0x03, 0x04})
+	assert.Panics(t, func() { MustNewBytesGroup(7) })
+}
+
 func TestGroup_MarshalCBOR_Bytes(t *testing.T) {
 	tv, err := NewBytesGroup(TestBytes)
 	require.NoError(t, err)

--- a/comid/instance.go
+++ b/comid/instance.go
@@ -189,6 +189,18 @@ func NewUEIDInstance(val any) (*Instance, error) {
 	return &Instance{ret}, nil
 }
 
+// MustNewBytesInstance is like NewBytesInstance except it does not return an
+// error, assuming that the provided value is valid. It panics if that isn't
+// the case.
+func MustNewBytesInstance(val any) *Instance {
+	ret, err := NewBytesInstance(val)
+	if err != nil {
+		panic(err)
+	}
+
+	return ret
+}
+
 // MustNewUEIDInstance is like NewUEIDInstance execept it does not return an
 // error, assuming that the provided value is valid. It panics if that isn't
 // the case.

--- a/comid/instance_test.go
+++ b/comid/instance_test.go
@@ -136,6 +136,11 @@ func Test_NewBytesInstance_NOK(t *testing.T) {
 	}
 }
 
+func Test_MustNewBytesInstance(t *testing.T) {
+	MustNewBytesInstance([]byte{0x01, 0x02, 0x03, 0x04})
+	assert.Panics(t, func() { MustNewBytesInstance(7) })
+}
+
 func TestInstance_MarshalCBOR_Bytes(t *testing.T) {
 	tv, err := NewBytesInstance(TestBytes)
 	require.NoError(t, err)


### PR DESCRIPTION
Add MustNewBytes(ClassID|Group|Instance) functions that call the corresponding NewBytes(ClassID|Group|Instance) function and panic on error.

This complementes the already existing
MustNewXXX(ClassID|Group|Instance) functions that exist for other underlying types XXX.