### PR TITLE
fix(comid): handle unset version scheme

### DIFF
--- a/comid/measurement_test.go
+++ b/comid/measurement_test.go
@@ -507,7 +507,7 @@ func TestMval_Valid(t *testing.T) {
 		mval := Mval{
 			Ver: &Version{
 				Version: "1.0",
-				Scheme:  scheme,
+				Scheme:  &scheme,
 			},
 		}
 		err := mval.Valid()

--- a/comid/version.go
+++ b/comid/version.go
@@ -11,8 +11,8 @@ import (
 
 // Version stores a version-map with JSON and CBOR serializations.
 type Version struct {
-	Version string             `cbor:"0,keyasint" json:"value"`
-	Scheme  swid.VersionScheme `cbor:"1,keyasint" json:"scheme"`
+	Version string              `cbor:"0,keyasint" json:"value"`
+	Scheme  *swid.VersionScheme `cbor:"1,keyasint,omitempty" json:"scheme,omitempty"`
 }
 
 func NewVersion() *Version {
@@ -28,9 +28,12 @@ func (o *Version) SetVersion(v string) *Version {
 
 func (o *Version) SetScheme(v int64) *Version {
 	if o != nil {
-		if o.Scheme.SetCode(v) != nil {
+		var scheme swid.VersionScheme
+		if scheme.SetCode(v) != nil {
 			return nil
 		}
+
+		o.Scheme = &scheme
 	}
 	return o
 }
@@ -43,7 +46,17 @@ func (o Version) Valid() error {
 }
 
 func (o Version) Equal(r Version) bool {
-	if o.Scheme != r.Scheme || o.Version != r.Version {
+	if o.Version != r.Version {
+		return false
+	}
+
+	if o.Scheme != nil {
+		if r.Scheme == nil {
+			return false
+		}
+
+		return *o.Scheme == *r.Scheme
+	} else if r.Scheme != nil {
 		return false
 	}
 

--- a/comid/version_test.go
+++ b/comid/version_test.go
@@ -47,3 +47,12 @@ func TestVersion_Equal_False(t *testing.T) {
 
 	assert.False(t, claim.Equal(*ref))
 }
+
+func TestVersion_no_scheme(t *testing.T) {
+	claim := NewVersion()
+	claim.SetVersion("1.55.22")
+
+	bytes, err := em.Marshal(claim)
+	assert.NoError(t, err)
+	assert.Equal(t, MustHexDecode(t, "a10067312e35352e3232"), bytes)
+}


### PR DESCRIPTION
The scheme part of a version-map is optional and so it should be possible to encode a Version without calling SetScheme(), however attempting to do so resulted in an error due to swid.VersionScheme being unable to deal with a nil inner value.

Change the type of the Scheme field to be a point to, rather than a swid.VersionScheme, and mark it as omitempty.