### PR TITLE
Minor refactor

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -13,12 +13,5 @@ jobs:
         go-version: "1.23"
     - name: Checkout code
       uses: actions/checkout@v2
-    - name: Install golangci-lint
-      run: |
-        go version
-        curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin v2.1.6
-    - name: Install mockgen
-      run: |
-        go install github.com/golang/mock/mockgen@v1.5.0
     - name: Run required linters in .golangci.yml plus hard-coded ones here
       run: make lint

--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@
 # vendor/
 
 mocks/
+
+# install location for project-local tools such as golangci-lint
+tools-bin/

--- a/Makefile
+++ b/Makefile
@@ -11,12 +11,23 @@ GOPKG += github.com/veraison/corim/encoding
 GOPKG += github.com/veraison/corim/extensions
 GOPKG += github.com/veraison/corim/coserv
 
-GOLINT ?= golangci-lint
-
 GOLINT_ARGS ?= run --timeout=3m -E dupl -E gocritic -E staticcheck -E lll -E prealloc
 
+TOPDIR := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
+
+GOLINT_VERSION = v2.1.6
+GOLINT = $(TOPDIR)/tools-bin/golangci-lint
+GOLINT_STAMP = $(TOPDIR)/tools-bin/golangci-lint-$(GOLINT_VERSION).stamp
+
+$(GOLINT): $(GOLINT_STAMP)
+
+$(GOLINT_STAMP):
+	mkdir -p $(dir $(GOLINT))
+	touch $(GOLINT_STAMP)
+	GOBIN=$(dir $(GOLINT)) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLINT_VERSION)
+
 .PHONY: lint
-lint:
+lint: $(GOLINT)
 	$(GOLINT) $(GOLINT_ARGS)
 
 ifeq ($(MAKECMDGOALS),test)

--- a/comid/cond_endorse_series_triple.go
+++ b/comid/cond_endorse_series_triple.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Contributors to the Veraison project.
+// Copyright 2025-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 package comid
@@ -50,46 +50,10 @@ func (o *CondEndorseSeriesRecord) RegisterExtensions(exts extensions.Map) error 
 	return nil
 }
 
-type CondEndorseSeriesRecords extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord]
+type CondEndorseSeriesRecords = extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord]
 
 func NewCondEndorseSeriesRecords() *CondEndorseSeriesRecords {
-	return (*CondEndorseSeriesRecords)(extensions.NewCollection[CondEndorseSeriesRecord]())
-}
-
-func (o *CondEndorseSeriesRecords) IsEmpty() bool {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).IsEmpty()
-}
-
-func (o *CondEndorseSeriesRecords) Add(val *CondEndorseSeriesRecord) *CondEndorseSeriesRecords {
-	ret := (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).Add(val)
-	return (*CondEndorseSeriesRecords)(ret)
-}
-
-func (o *CondEndorseSeriesRecords) GetExtensions() extensions.IMapValue {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).GetExtensions()
-}
-
-func (o *CondEndorseSeriesRecords) RegisterExtensions(exts extensions.Map) error {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).RegisterExtensions(exts)
-}
-
-func (o *CondEndorseSeriesRecords) Valid() error {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).Valid()
-}
-
-func (o CondEndorseSeriesRecords) MarshalCBOR() ([]byte, error) {
-	return (extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).MarshalCBOR()
-}
-
-func (o *CondEndorseSeriesRecords) UnmarshalCBOR(data []byte) error {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).UnmarshalCBOR(data)
-}
-func (o CondEndorseSeriesRecords) MarshalJSON() ([]byte, error) {
-	return (extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).MarshalJSON()
-}
-
-func (o *CondEndorseSeriesRecords) UnmarshalJSON(data []byte) error {
-	return (*extensions.Collection[CondEndorseSeriesRecord, *CondEndorseSeriesRecord])(o).UnmarshalJSON(data)
+	return extensions.NewCollection[CondEndorseSeriesRecord]()
 }
 
 // The Conditional Endorsement Series Triple is used to assert endorsed values based
@@ -132,45 +96,8 @@ func (o *CondEndorseSeriesTriple) GetExtensions() extensions.IMapValue {
 
 // CondEndorseSeriesTriples is a container for CondEndorseSeriesTriple instances and their extensions.
 // It is a thin wrapper around extensions.Collection.
-type CondEndorseSeriesTriples extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple]
+type CondEndorseSeriesTriples = extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple]
 
 func NewCondEndorseSeriesTriples() *CondEndorseSeriesTriples {
-	return (*CondEndorseSeriesTriples)(extensions.NewCollection[CondEndorseSeriesTriple]())
-}
-
-func (o *CondEndorseSeriesTriples) GetExtensions() extensions.IMapValue {
-	return (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).GetExtensions()
-}
-
-func (o *CondEndorseSeriesTriples) RegisterExtensions(exts extensions.Map) error {
-	return (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).RegisterExtensions(exts)
-}
-
-func (o CondEndorseSeriesTriples) Valid() error {
-	return (extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).Valid()
-}
-
-func (o *CondEndorseSeriesTriples) IsEmpty() bool {
-	return (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).IsEmpty()
-}
-
-func (o *CondEndorseSeriesTriples) Add(val *CondEndorseSeriesTriple) *CondEndorseSeriesTriples {
-	ret := (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).Add(val)
-	return (*CondEndorseSeriesTriples)(ret)
-}
-
-func (o CondEndorseSeriesTriples) MarshalCBOR() ([]byte, error) {
-	return (extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).MarshalCBOR()
-}
-
-func (o *CondEndorseSeriesTriples) UnmarshalCBOR(data []byte) error {
-	return (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).UnmarshalCBOR(data)
-}
-
-func (o CondEndorseSeriesTriples) MarshalJSON() ([]byte, error) {
-	return (extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).MarshalJSON()
-}
-
-func (o *CondEndorseSeriesTriples) UnmarshalJSON(data []byte) error {
-	return (*extensions.Collection[CondEndorseSeriesTriple, *CondEndorseSeriesTriple])(o).UnmarshalJSON(data)
+	return extensions.NewCollection[CondEndorseSeriesTriple]()
 }

--- a/comid/measurement.go
+++ b/comid/measurement.go
@@ -788,44 +788,8 @@ func (o Measurement) Valid() error {
 
 // Measurements is a container for Measurement instances and their extensions.
 // It is a thin wrapper around extensions.Collection.
-type Measurements extensions.Collection[Measurement, *Measurement]
+type Measurements = extensions.Collection[Measurement, *Measurement]
 
 func NewMeasurements() *Measurements {
-	return (*Measurements)(extensions.NewCollection[Measurement]())
-}
-
-func (o *Measurements) RegisterExtensions(exts extensions.Map) error {
-	return (*extensions.Collection[Measurement, *Measurement])(o).RegisterExtensions(exts)
-}
-
-func (o *Measurements) GetExtensions() extensions.IMapValue {
-	return (*extensions.Collection[Measurement, *Measurement])(o).GetExtensions()
-}
-
-func (o *Measurements) Valid() error {
-	return (*extensions.Collection[Measurement, *Measurement])(o).Valid()
-}
-
-func (o *Measurements) IsEmpty() bool {
-	return (*extensions.Collection[Measurement, *Measurement])(o).IsEmpty()
-}
-
-func (o *Measurements) Add(val *Measurement) *Measurements {
-	ret := (*extensions.Collection[Measurement, *Measurement])(o).Add(val)
-	return (*Measurements)(ret)
-}
-
-func (o Measurements) MarshalCBOR() ([]byte, error) {
-	return (extensions.Collection[Measurement, *Measurement])(o).MarshalCBOR()
-}
-
-func (o *Measurements) UnmarshalCBOR(data []byte) error {
-	return (*extensions.Collection[Measurement, *Measurement])(o).UnmarshalCBOR(data)
-}
-func (o Measurements) MarshalJSON() ([]byte, error) {
-	return (extensions.Collection[Measurement, *Measurement])(o).MarshalJSON()
-}
-
-func (o *Measurements) UnmarshalJSON(data []byte) error {
-	return (*extensions.Collection[Measurement, *Measurement])(o).UnmarshalJSON(data)
+	return extensions.NewCollection[Measurement]()
 }

--- a/comid/valuetriple.go
+++ b/comid/valuetriple.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Contributors to the Veraison project.
+// Copyright 2021-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 package comid
@@ -47,45 +47,8 @@ func (o ValueTriple) Valid() error {
 
 // ValueTriples is a container for ValueTriple instances and their extensions.
 // It is a thin wrapper around extensions.Collection.
-type ValueTriples extensions.Collection[ValueTriple, *ValueTriple]
+type ValueTriples = extensions.Collection[ValueTriple, *ValueTriple]
 
 func NewValueTriples() *ValueTriples {
-	return (*ValueTriples)(extensions.NewCollection[ValueTriple]())
-}
-
-func (o *ValueTriples) RegisterExtensions(exts extensions.Map) error {
-	return (*extensions.Collection[ValueTriple, *ValueTriple])(o).RegisterExtensions(exts)
-}
-
-func (o *ValueTriples) GetExtensions() extensions.IMapValue {
-	return (*extensions.Collection[ValueTriple, *ValueTriple])(o).GetExtensions()
-}
-
-func (o ValueTriples) Valid() error {
-	return (extensions.Collection[ValueTriple, *ValueTriple])(o).Valid()
-}
-
-func (o *ValueTriples) IsEmpty() bool {
-	return (*extensions.Collection[ValueTriple, *ValueTriple])(o).IsEmpty()
-}
-
-func (o *ValueTriples) Add(val *ValueTriple) *ValueTriples {
-	ret := (*extensions.Collection[ValueTriple, *ValueTriple])(o).Add(val)
-	return (*ValueTriples)(ret)
-}
-
-func (o ValueTriples) MarshalCBOR() ([]byte, error) {
-	return (extensions.Collection[ValueTriple, *ValueTriple])(o).MarshalCBOR()
-}
-
-func (o *ValueTriples) UnmarshalCBOR(data []byte) error {
-	return (*extensions.Collection[ValueTriple, *ValueTriple])(o).UnmarshalCBOR(data)
-}
-
-func (o ValueTriples) MarshalJSON() ([]byte, error) {
-	return (extensions.Collection[ValueTriple, *ValueTriple])(o).MarshalJSON()
-}
-
-func (o *ValueTriples) UnmarshalJSON(data []byte) error {
-	return (*extensions.Collection[ValueTriple, *ValueTriple])(o).UnmarshalJSON(data)
+	return extensions.NewCollection[ValueTriple]()
 }

--- a/corim/entity.go
+++ b/corim/entity.go
@@ -1,4 +1,4 @@
-// Copyright 2021-2024 Contributors to the Veraison project.
+// Copyright 2021-2026 Contributors to the Veraison project.
 // SPDX-License-Identifier: Apache-2.0
 
 package corim
@@ -128,47 +128,10 @@ func (o Entity) MarshalJSON() ([]byte, error) {
 
 // Entities is a container for Entity instances and their extensions.
 // It is a thin wrapper around extensions.Collection.
-type Entities extensions.Collection[Entity, *Entity]
+type Entities = extensions.Collection[Entity, *Entity]
 
 func NewEntities() *Entities {
-	return (*Entities)(extensions.NewCollection[Entity]())
-}
-
-func (o *Entities) RegisterExtensions(exts extensions.Map) error {
-	return (*extensions.Collection[Entity, *Entity])(o).RegisterExtensions(exts)
-}
-
-func (o *Entities) GetExtensions() extensions.IMapValue {
-	return (*extensions.Collection[Entity, *Entity])(o).GetExtensions()
-}
-
-func (o *Entities) Valid() error {
-	return (*extensions.Collection[Entity, *Entity])(o).Valid()
-}
-
-func (o *Entities) IsEmpty() bool {
-	return (*extensions.Collection[Entity, *Entity])(o).IsEmpty()
-}
-
-func (o *Entities) Add(val *Entity) *Entities {
-	ret := (*extensions.Collection[Entity, *Entity])(o).Add(val)
-	return (*Entities)(ret)
-}
-
-func (o Entities) MarshalCBOR() ([]byte, error) {
-	return (extensions.Collection[Entity, *Entity])(o).MarshalCBOR()
-}
-
-func (o *Entities) UnmarshalCBOR(data []byte) error {
-	return (*extensions.Collection[Entity, *Entity])(o).UnmarshalCBOR(data)
-}
-
-func (o Entities) MarshalJSON() ([]byte, error) {
-	return (extensions.Collection[Entity, *Entity])(o).MarshalJSON()
-}
-
-func (o *Entities) UnmarshalJSON(data []byte) error {
-	return (*extensions.Collection[Entity, *Entity])(o).UnmarshalJSON(data)
+	return extensions.NewCollection[Entity]()
 }
 
 // EntityName encapsulates the name of the associated Entity. The CoRIM

--- a/go.mod
+++ b/go.mod
@@ -2,8 +2,6 @@ module github.com/veraison/corim
 
 go 1.23.0
 
-toolchain go1.24.2
-
 require (
 	fortio.org/safecast v1.0.0
 	github.com/fxamacker/cbor/v2 v2.8.0


### PR DESCRIPTION
- Type alias `extensions.Collection` instances for specific types, removing the need to "re-export" all of `extensions.Collection` methods.
- Switch to using repo-local `golangci-lint` to avoid potential clashes with system-installed version. 