### PR TITLE
Enable TDX profile extensions for conditional endorsement series values

### DIFF
--- a/corim/profiles.go
+++ b/corim/profiles.go
@@ -39,6 +39,8 @@ var ComidMapExtensionPoints = []extensions.Point{
 	comid.ExtReferenceValueFlags,
 	comid.ExtEndorsedValue,
 	comid.ExtEndorsedValueFlags,
+	comid.ExtCondEndorseSeriesValue,
+	comid.ExtCondEndorseSeriesValueFlags,
 }
 
 // AllExtensionPoints is a list of all valid extension.Point's

--- a/profiles/tdx/mval_extensions.go
+++ b/profiles/tdx/mval_extensions.go
@@ -50,7 +50,8 @@ func init() {
 
 	extMap := extensions.NewMap().
 		Add(comid.ExtReferenceValue, &MValExtensions{}).
-		Add(comid.ExtEndorsedValue, &MValExtensions{})
+		Add(comid.ExtEndorsedValue, &MValExtensions{}).
+		Add(comid.ExtCondEndorseSeriesValue, &MValExtensions{})
 
 	if err := corim.RegisterProfile(profileID, extMap); err != nil {
 		// will not error, assuming our profile ID is unique, and we've


### PR DESCRIPTION
[Copilot generated]

This pull request adds support for the `ExtCondEndorseSeriesValue` and `ExtCondEndorseSeriesValueFlags` extension points to the TDX profile, ensuring these extension points are recognized and handled properly. The main changes are:

**Extension Point Support:**

* Added `comid.ExtCondEndorseSeriesValue` and `comid.ExtCondEndorseSeriesValueFlags` to the `ComidMapExtensionPoints` list in `corim/profiles.go`, allowing these extension points to be recognized as valid.

**Profile Registration:**

* Updated the TDX profile extension map in `profiles/tdx/mval_extensions.go` to register `comid.ExtCondEndorseSeriesValue` with the `MValExtensions` handler, ensuring it is processed correctly during profile registration.