### PR TITLE
feat(cotl): add Concise Tag List (CoTL) package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ GOPKG += github.com/veraison/corim/encoding
 GOPKG += github.com/veraison/corim/extensions
 GOPKG += github.com/veraison/corim/coserv
 GOPKG += github.com/veraison/corim/coev
+GOPKG += github.com/veraison/corim/cotl
 
 GOLINT_ARGS ?= run --timeout=3m -E dupl -E gocritic -E staticcheck -E lll -E prealloc
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 The [`corim/corim`](corim) and [`corim/comid`](comid) packages provide a golang API for low-level manipulation of [Concise Reference Integrity Manifest (CoRIM)](https://datatracker.ietf.org/doc/draft-ietf-rats-corim/) and Concise Module Identifier (CoMID) tags respectively.
 The [`corim/coev`](coev) package provides a golang implementation of TCG Concise Evidence CDDL as documented [here](https://github.com/TrustedComputingGroup/dice-coev/blob/main/concise-evidence.cddl).
 The [`corim/coserv`](coserv) package provides a golang API for working with [Concise Selector for Endorsements and Reference Values](https://datatracker.ietf.org/doc/draft-howard-rats-coserv).
+The [`corim/cotl`](cotl) package provides a golang implementation of the Concise Tag List (CoTL) data structure defined in Section 6 of [draft-ietf-rats-corim-11](https://datatracker.ietf.org/doc/draft-ietf-rats-corim/).
 
 > [!NOTE]
 > These API are still in active development (as is the underlying CoRIM spec).

--- a/cotl/cotl.go
+++ b/cotl/cotl.go
@@ -1,0 +1,259 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+// Package cotl implements the Concise Tag List (CoTL) data structure defined
+// in Section 6 of draft-ietf-rats-corim-11, including CBOR (tag 508) and JSON
+// serialization, validation, temporal appraisal checks, and Veraison-style
+// map extensions on the concise-tl-tag extension point.
+package cotl
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	cbor "github.com/fxamacker/cbor/v2"
+	"github.com/veraison/corim/corim"
+	"github.com/veraison/corim/encoding"
+	"github.com/veraison/corim/extensions"
+	"github.com/veraison/swid"
+)
+
+// CotlTag is the CBOR tag number for a tagged-concise-tl-tag
+// (draft-ietf-rats-corim-11, Section 6).
+const CotlTag uint64 = 508
+
+var (
+	em cbor.EncMode
+	dm cbor.DecMode
+)
+
+func init() {
+	encOpt := cbor.EncOptions{
+		Sort:          cbor.SortCoreDeterministic,
+		IndefLength:   cbor.IndefLengthForbidden,
+		NilContainers: cbor.NilContainerAsEmpty,
+		TimeTag:       cbor.EncTagRequired,
+	}
+
+	m, err := encOpt.EncMode()
+	if err != nil {
+		panic(err)
+	}
+	em = m
+
+	d, err := cbor.DecOptions{
+		IndefLength: cbor.IndefLengthAllowed,
+		TimeTag:     cbor.DecTagOptional,
+	}.DecMode()
+	if err != nil {
+		panic(err)
+	}
+	dm = d
+}
+
+// TagIdentityMap identifies a CoMID or CoSWID tag, either as the identity of
+// the CoTL itself or as an entry in its tags-list.
+type TagIdentityMap struct {
+	TagID      swid.TagID `cbor:"0,keyasint" json:"tag-id"`
+	TagVersion *uint      `cbor:"1,keyasint,omitempty" json:"tag-version,omitempty"`
+}
+
+// NewTagIdentityMap returns a TagIdentityMap for the supplied identifier,
+// which may be a string (text or UUID form), UUID bytes, or a uuid.UUID.
+func NewTagIdentityMap(v interface{}) (*TagIdentityMap, error) {
+	tagID := swid.NewTagID(v)
+	if tagID == nil {
+		return nil, fmt.Errorf("invalid tag-id: %T", v)
+	}
+	return &TagIdentityMap{TagID: *tagID}, nil
+}
+
+// Valid returns nil if the tag identity carries a usable identifier.
+func (o TagIdentityMap) Valid() error {
+	if o.TagID == (swid.TagID{}) {
+		return errors.New("empty tag-id")
+	}
+	return nil
+}
+
+// String renders the identifier in human-readable form.
+func (o TagIdentityMap) String() string {
+	s := o.TagID.String()
+	if o.TagVersion != nil {
+		return fmt.Sprintf("%s (version %d)", s, *o.TagVersion)
+	}
+	return s
+}
+
+// ConciseTlTag is the concise-tl-tag structure from draft-ietf-rats-corim-11,
+// Section 6.1:
+//
+//	concise-tl-tag = {
+//	  &(tag-identity: 0) => tag-identity-map
+//	  &(tags-list: 1) => [ + tag-identity-map ],
+//	  &(tl-validity: 2) => validity-map
+//	}
+//
+// All tags listed in TagsList are activated atomically: either every tag is
+// available to the Verifier, or the entire CoTL is rejected (Section 6).
+type ConciseTlTag struct {
+	TagIdentity TagIdentityMap   `cbor:"0,keyasint" json:"tag-identity"`
+	TagsList    []TagIdentityMap `cbor:"1,keyasint" json:"tags-list"`
+	TlValidity  corim.Validity   `cbor:"2,keyasint" json:"tl-validity"`
+
+	extensions.Extensions
+}
+
+// Valid performs structural validation per Section 6.1: the tags-list must be
+// non-empty (activation is atomic), every entry must have a valid identity,
+// and the validity window must not be inverted.
+func (o *ConciseTlTag) Valid() error {
+	if err := o.TagIdentity.Valid(); err != nil {
+		return fmt.Errorf("invalid tag-identity: %w", err)
+	}
+
+	if len(o.TagsList) == 0 {
+		return ErrEmptyTagsList
+	}
+
+	for i, t := range o.TagsList {
+		if err := t.Valid(); err != nil {
+			return fmt.Errorf("invalid tags-list entry %d: %w", i, err)
+		}
+	}
+
+	if err := o.TlValidity.Valid(); err != nil {
+		return fmt.Errorf("invalid tl-validity: %w", err)
+	}
+
+	if err := o.validExtensions(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ToCBOR serializes the CoTL as deterministic CBOR wrapped in CBOR tag 508.
+func (o *ConciseTlTag) ToCBOR() ([]byte, error) {
+	if err := o.Valid(); err != nil {
+		return nil, err
+	}
+
+	buf, err := encoding.SerializeStructToCBOR(em, o)
+	if err != nil {
+		return nil, fmt.Errorf("CBOR encoding failed: %w", err)
+	}
+
+	var out bytes.Buffer
+	if err := cbor.NewEncoder(&out).Encode(cbor.Tag{Number: CotlTag, Content: buf}); err != nil {
+		return nil, fmt.Errorf("tag wrapping failed: %w", err)
+	}
+
+	return out.Bytes(), nil
+}
+
+// FromCBOR parses CBOR bytes into a ConciseTlTag. Both the tagged (#6.508)
+// and untagged forms are accepted for interoperability with processors that
+// convey the bare map.
+func (o *ConciseTlTag) FromCBOR(buf []byte) error {
+	content, err := unwrapCotlTag(buf)
+	if err != nil {
+		return err
+	}
+
+	if err := populateSafely(o, content); err != nil {
+		return err
+	}
+
+	if err := o.Valid(); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	return nil
+}
+
+// unwrapCotlTag verifies that buf carries CBOR tag 508 (if any) and returns
+// the enclosed concise-tl-tag map bytes.
+func unwrapCotlTag(buf []byte) ([]byte, error) {
+	var tag cbor.Tag
+	if err := dm.Unmarshal(buf, &tag); err != nil {
+		// Not a tagged message: assume bare map.
+		return buf, nil
+	}
+
+	if tag.Number != CotlTag {
+		return nil, fmt.Errorf("expected CBOR tag %d, got %d", CotlTag, tag.Number)
+	}
+
+	content, ok := tag.Content.([]byte)
+	if !ok {
+		return nil, errors.New("tag content is not a byte string")
+	}
+
+	return content, nil
+}
+
+// populateSafely wraps CBOR struct decoding so that panics on malformed
+// input are surfaced as errors instead of crashing the calling process.
+func populateSafely(o *ConciseTlTag, content []byte) (err error) {
+	defer func() {
+		if r := recover(); r != nil {
+			err = fmt.Errorf("CBOR decoding failed: %v", r)
+		}
+	}()
+
+	// Gate on RFC 8949 well-formedness first: the corim encoding helpers do
+	// not defend against malformed map headers (they can loop indefinitely).
+	if err := dm.Wellformed(content); err != nil {
+		return fmt.Errorf("malformed CBOR: %w", err)
+	}
+
+	// Note: the corim encoding helpers (rather than plain Unmarshal) are
+	// deliberate here so that any extension structs previously passed to
+	// RegisterExtensions() are resolved through their embedded interface
+	// and populated from the wire form.
+	if err := encoding.PopulateStructFromCBOR(dm, content, o); err != nil {
+		return fmt.Errorf("CBOR decoding failed: %w", err)
+	}
+
+	return nil
+}
+
+// NewConciseTlTagFromCBOR parses tagged or untagged CoTL CBOR bytes.
+func NewConciseTlTagFromCBOR(buf []byte) (*ConciseTlTag, error) {
+	cotl := new(ConciseTlTag)
+	if err := cotl.FromCBOR(buf); err != nil {
+		return nil, err
+	}
+
+	return cotl, nil
+}
+
+// ToJSON serializes the CoTL to human-readable JSON.
+func (o *ConciseTlTag) ToJSON() ([]byte, error) {
+	if err := o.Valid(); err != nil {
+		return nil, err
+	}
+
+	buf, err := json.Marshal(o)
+	if err != nil {
+		return nil, fmt.Errorf("JSON encoding failed: %w", err)
+	}
+
+	return buf, nil
+}
+
+// FromJSON parses human-readable JSON into a ConciseTlTag.
+func (o *ConciseTlTag) FromJSON(buf []byte) error {
+	if err := json.Unmarshal(buf, o); err != nil {
+		return fmt.Errorf("JSON decoding failed: %w", err)
+	}
+
+	if err := o.Valid(); err != nil {
+		return fmt.Errorf("validation failed: %w", err)
+	}
+
+	return nil
+}

--- a/cotl/cotl.go
+++ b/cotl/cotl.go
@@ -53,8 +53,8 @@ func init() {
 	dm = d
 }
 
-// TagIdentityMap identifies a CoMID or CoSWID tag, either as the identity of
-// the CoTL itself or as an entry in its tags-list.
+// TagIdentityMap identifies a CoMID or CoSWID tag, as an entry in its tags-list or
+// as the identity of the CoTL itself
 type TagIdentityMap struct {
 	TagID      swid.TagID `cbor:"0,keyasint" json:"tag-id"`
 	TagVersion *uint      `cbor:"1,keyasint,omitempty" json:"tag-version,omitempty"`

--- a/cotl/cotl_test.go
+++ b/cotl/cotl_test.go
@@ -1,0 +1,574 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cotl
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"math/rand"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/veraison/corim/corim"
+	"github.com/veraison/corim/extensions"
+)
+
+// test helpers ---------------------------------------------------------------
+
+func mustTagIdentity(t *testing.T, v interface{}) TagIdentityMap {
+	t.Helper()
+
+	tm, err := NewTagIdentityMap(v)
+	if err != nil {
+		t.Fatalf("NewTagIdentityMap(%v) failed: %v", v, err)
+	}
+
+	return *tm
+}
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+
+	ts, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("time parse %q failed: %v", s, err)
+	}
+
+	return ts
+}
+
+func validCotl(t *testing.T) ConciseTlTag {
+	t.Helper()
+
+	return ConciseTlTag{
+		TagIdentity: mustTagIdentity(t, "test-cotl"),
+		TagsList: []TagIdentityMap{
+			mustTagIdentity(t, "123e4567-e89b-12d3-a456-426614174000"),
+			mustTagIdentity(t, "component-fw"),
+		},
+		TlValidity: corim.Validity{
+			NotBefore: ptrTime(mustTime(t, "2020-01-01T00:00:00Z")),
+			NotAfter:  mustTime(t, "2100-01-01T00:00:00Z"),
+		},
+	}
+}
+
+func ptrTime(ts time.Time) *time.Time {
+	return &ts
+}
+
+// construction & validation --------------------------------------------------
+
+func TestNewTagIdentityMap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   interface{}
+		wantErr bool
+	}{
+		{"text id", "component-fw", false},
+		{"canonical uuid", "123e4567-e89b-12d3-a456-426614174000", false},
+		// Deliberately accepted so draft Section 4.3.1's recommended
+		// urn:uuid:<uuid> reference form works verbatim.
+		{"urn uuid form", "urn:uuid:123e4567-e89b-12d3-a456-426614174000", false},
+		{"uuid bytes", uuid.MustParse("123e4567-e89b-12d3-a456-426614174000"), false},
+		{"empty string", "", true},
+		{"unsupported type", 42, true},
+		{"nil", nil, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tm, err := NewTagIdentityMap(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("NewTagIdentityMap(%v) error = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if !tt.wantErr && tm == nil {
+				t.Fatalf("NewTagIdentityMap(%v) = nil, want non-nil", tt.input)
+			}
+		})
+	}
+}
+
+func TestConciseTlTagValid(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(*ConciseTlTag)
+		wantErr bool
+	}{
+		{"fully valid", func(_ *ConciseTlTag) {}, false},
+		{"no tag identity", func(o *ConciseTlTag) { o.TagIdentity = TagIdentityMap{} }, true},
+		{
+			"invalid entry in tags list",
+			func(o *ConciseTlTag) { o.TagsList[1] = TagIdentityMap{} },
+			true,
+		},
+		{
+			"inverted validity window",
+			func(o *ConciseTlTag) {
+				o.TlValidity = corim.Validity{
+					NotBefore: ptrTime(mustTime(t, "2100-01-01T00:00:00Z")),
+					NotAfter:  mustTime(t, "2020-01-01T00:00:00Z"),
+				}
+			},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cotl := validCotl(t)
+			tt.mutate(&cotl)
+
+			err := cotl.Valid()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Valid() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestEmptyTagsListIsSentinelError(t *testing.T) {
+	t.Parallel()
+
+	cotl := validCotl(t)
+	cotl.TagsList = nil
+
+	if err := cotl.Valid(); !errors.Is(err, ErrEmptyTagsList) {
+		t.Fatalf("Valid() error = %v, want ErrEmptyTagsList", err)
+	}
+}
+
+func TestEmptyTagsListRejectedByEncoders(t *testing.T) {
+	t.Parallel()
+
+	cotl := validCotl(t)
+	cotl.TagsList = nil
+
+	if _, err := cotl.ToCBOR(); !errors.Is(err, ErrEmptyTagsList) {
+		t.Errorf("ToCBOR() error = %v, want ErrEmptyTagsList", err)
+	}
+
+	if _, err := cotl.ToJSON(); !errors.Is(err, ErrEmptyTagsList) {
+		t.Errorf("ToJSON() error = %v, want ErrEmptyTagsList", err)
+	}
+}
+
+func TestEmptyStructRejectedByDecoders(t *testing.T) {
+	t.Parallel()
+
+	var fromJSON ConciseTlTag
+	if err := fromJSON.FromJSON([]byte(`{}`)); err == nil {
+		t.Error("empty JSON object accepted")
+	}
+}
+
+// serialization round-trips --------------------------------------------------
+
+func TestCBORRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := validCotl(t)
+
+	buf, err := want.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR() failed: %v", err)
+	}
+
+	got, err := NewConciseTlTagFromCBOR(buf)
+	if err != nil {
+		t.Fatalf("NewConciseTlTagFromCBOR() failed: %v", err)
+	}
+
+	if got.TagIdentity.String() != want.TagIdentity.String() {
+		t.Errorf("tag-identity = %v, want %v", got.TagIdentity.String(), want.TagIdentity.String())
+	}
+
+	if len(got.TagsList) != len(want.TagsList) {
+		t.Fatalf("tags-list length = %d, want %d", len(got.TagsList), len(want.TagsList))
+	}
+
+	for i := range want.TagsList {
+		if got.TagsList[i].String() != want.TagsList[i].String() {
+			t.Errorf("tags-list[%d] = %v, want %v", i, got.TagsList[i].String(), want.TagsList[i].String())
+		}
+	}
+
+	if !got.TlValidity.NotAfter.Equal(want.TlValidity.NotAfter) {
+		t.Errorf("not-after = %v, want %v", got.TlValidity.NotAfter, want.TlValidity.NotAfter)
+	}
+}
+
+func TestCBORRoundTripIsDeterministic(t *testing.T) {
+	t.Parallel()
+
+	cotl1 := validCotl(t)
+	cotl2 := validCotl(t)
+	a, _ := cotl1.ToCBOR()
+	b, _ := cotl2.ToCBOR()
+
+	if !bytes.Equal(a, b) {
+		t.Error("repeated encoding of identical CoTL produced different bytes")
+	}
+}
+
+func TestCBORRoundTripPreservesVersion(t *testing.T) {
+	t.Parallel()
+
+	v := uint(42)
+	want := validCotl(t)
+	want.TagIdentity.TagVersion = &v
+
+	buf, err := want.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR() failed: %v", err)
+	}
+
+	got, err := NewConciseTlTagFromCBOR(buf)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+
+	if got.TagIdentity.TagVersion == nil || *got.TagIdentity.TagVersion != v {
+		t.Errorf("tag-version = %v, want %d", got.TagIdentity.TagVersion, v)
+	}
+}
+
+func TestUntaggedCBORAccepted(t *testing.T) {
+	t.Parallel()
+
+	c := validCotl(t)
+	tagged, err := c.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR() failed: %v", err)
+	}
+
+	var inner []byte
+	if unwrapErr := unmarshalTag(tagged, &inner); unwrapErr != nil {
+		t.Fatalf("unwrap failed: %v", unwrapErr)
+	}
+
+	got, err := NewConciseTlTagFromCBOR(inner)
+	if err != nil {
+		t.Fatalf("untagged decode failed: %v", err)
+	}
+
+	if got.TagIdentity.String() != "test-cotl" {
+		t.Errorf("tag-identity = %q, want %q", got.TagIdentity.String(), "test-cotl")
+	}
+}
+
+func unmarshalTag(buf []byte, out interface{}) error {
+	dmLocal, err := cborDecOptions().DecMode()
+	if err != nil {
+		return err
+	}
+
+	return dmLocal.Unmarshal(buf, out)
+}
+
+func TestWrongCBORTagNumberRejected(t *testing.T) {
+	t.Parallel()
+
+	c := validCotl(t)
+	tagged, err := c.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR() failed: %v", err)
+	}
+
+	// Flip tag 508 to 505 (CoSWID).
+	wrong := append([]byte{}, tagged...)
+	wrong[2] = 0x01 // 501+4 => 505 in the 3-byte tag header
+
+	if _, err := NewConciseTlTagFromCBOR(wrong); err == nil {
+		t.Fatal("wrong tag number accepted")
+	} else if !containsStr(err.Error(), "expected CBOR tag 508") {
+		t.Errorf("error = %v, want wrong-tag diagnostic", err)
+	}
+}
+
+func containsStr(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || sub == "" || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+
+	return -1
+}
+
+func TestTruncatedInputsRejected(t *testing.T) {
+	t.Parallel()
+
+	c := validCotl(t)
+	full, err := c.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR() failed: %v", err)
+	}
+
+	for _, cut := range []int{0, 1, 2, 3, 7, len(full) / 2, len(full) - 1} {
+		if _, err := NewConciseTlTagFromCBOR(full[:cut]); err == nil {
+			t.Errorf("truncation at %d bytes was accepted", cut)
+		}
+	}
+}
+
+// fuzz-lite: decoding arbitrary bytes must return an error or a result —
+// never a panic. Uses a deterministic LCG for reproducibility.
+func TestDecodeNeverPanicsOnArbitraryBytes(t *testing.T) {
+	t.Parallel()
+
+	rng := rand.New(rand.NewSource(0xDEADBEEF)) // #nosec G404 -- deterministic fuzz-lite input, not security-sensitive
+
+	for i := 0; i < 2000; i++ {
+		if testing.Short() && i > 200 {
+			break
+		}
+		buf := make([]byte, rng.Intn(96))
+		if _, err := rng.Read(buf); err != nil {
+			t.Fatalf("rng read failed: %v", err)
+		}
+
+		func() {
+			defer func() {
+				if r := recover(); r != nil {
+					t.Fatalf("panic on input #%d (%x): %v", i, buf, r)
+				}
+			}()
+
+			_, _ = NewConciseTlTagFromCBOR(buf)
+		}()
+	}
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	want := validCotl(t)
+
+	j, err := want.ToJSON()
+	if err != nil {
+		t.Fatalf("ToJSON() failed: %v", err)
+	}
+
+	var got ConciseTlTag
+	if err := got.FromJSON(j); err != nil {
+		t.Fatalf("FromJSON() failed: %v", err)
+	}
+
+	if got.TagIdentity.String() != want.TagIdentity.String() {
+		t.Errorf("tag-identity = %v, want %v", got.TagIdentity.String(), want.TagIdentity.String())
+	}
+
+	if len(got.TagsList) != len(want.TagsList) {
+		t.Errorf("tags-list length = %d, want %d", len(got.TagsList), len(want.TagsList))
+	}
+
+	if !got.TlValidity.NotAfter.Equal(want.TlValidity.NotAfter) {
+		t.Errorf("not-after = %v, want %v", got.TlValidity.NotAfter, want.TlValidity.NotAfter)
+	}
+
+	if !reflect.DeepEqual(got.TagsList[0], want.TagsList[0]) {
+		t.Errorf("tags-list[0] = %+v, want %+v", got.TagsList[0], want.TagsList[0])
+	}
+}
+
+func TestJSONRejectsUnknownFields(t *testing.T) {
+	t.Parallel()
+
+	var cotl ConciseTlTag
+	if err := cotl.FromJSON([]byte(`{"bogus-field": true}`)); err == nil {
+		t.Fatal("unknown JSON field accepted")
+	}
+}
+
+// temporal validation ---------------------------------------------------------
+
+func TestValidateAtBoundaries(t *testing.T) {
+	t.Parallel()
+
+	notBefore := mustTime(t, "2020-01-01T00:00:00Z")
+	notAfter := mustTime(t, "2030-01-01T00:00:00Z")
+
+	base := func() ConciseTlTag {
+		c := ConciseTlTag{
+			TagIdentity: mustTagIdentity(t, "id"),
+			TagsList:    []TagIdentityMap{mustTagIdentity(t, "t")},
+			TlValidity: corim.Validity{
+				NotBefore: ptrTime(notBefore),
+				NotAfter:  notAfter,
+			},
+		}
+
+		if err := c.Valid(); err != nil {
+			t.Fatalf("fixture invalid: %v", err)
+		}
+
+		return c
+	}
+
+	tests := []struct {
+		name        string
+		now         time.Time
+		wantValid   bool
+		wantWarning bool
+	}{
+		{"before window", notBefore.Add(-time.Second), true, true},
+		{"at not-before", notBefore, true, false},
+		{"mid-window", notBefore.Add(time.Hour), true, false},
+		{"at not-after", notAfter, true, false},
+		{"after not-after", notAfter.Add(time.Second), false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := base()
+			report := c.ValidateAt(tt.now)
+
+			if report.Valid() != tt.wantValid {
+				t.Errorf("ValidateAt(%v).Valid() = %t, errors = %v",
+					tt.now, report.Valid(), report.Errors)
+			}
+
+			hasWarning := len(report.Warnings) > 0
+			if hasWarning != tt.wantWarning {
+				t.Errorf("ValidateAt(%v) warnings = %v, want warning presence %t",
+					tt.now, report.Warnings, tt.wantWarning)
+			}
+		})
+	}
+}
+
+func TestValidateAtReportsDuplicates(t *testing.T) {
+	t.Parallel()
+
+	cotl := ConciseTlTag{
+		TagIdentity: mustTagIdentity(t, "id"),
+		TagsList: []TagIdentityMap{
+			mustTagIdentity(t, "dup"),
+			mustTagIdentity(t, "dup"),
+			mustTagIdentity(t, "dup"),
+			mustTagIdentity(t, "other"),
+		},
+		TlValidity: corim.Validity{NotAfter: mustTime(t, "2100-01-01T00:00:00Z")},
+	}
+
+	report := cotl.ValidateAt(time.Now())
+
+	if n := countContains(report.Warnings, "duplicate"); n != 2 {
+		t.Errorf("%d duplicate warnings, want 2 (warnings: %v)", n, report.Warnings)
+	}
+}
+
+func countContains(list []string, sub string) int {
+	n := 0
+
+	for _, s := range list {
+		if containsStr(s, sub) {
+			n++
+		}
+	}
+
+	return n
+}
+
+// extensions -----------------------------------------------------------------
+
+type testExt struct {
+	Foo string `cbor:"6001" json:"foo"`
+}
+
+type constrainingExt struct {
+	MaxTags int `cbor:"6002" json:"max-tags"`
+}
+
+func (o constrainingExt) ConstrainConciseTlTag(c *ConciseTlTag) error {
+	if len(c.TagsList) > o.MaxTags {
+		return fmt.Errorf("tags-list exceeds extension limit of %d", o.MaxTags)
+	}
+
+	return nil
+}
+
+func TestRegisterExtensionsRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	cotl := validCotl(t)
+	if err := cotl.RegisterExtensions(extensions.NewMap().Add(ExtConciseTlTag, &testExt{Foo: "bar"})); err != nil {
+		t.Fatalf("RegisterExtensions failed: %v", err)
+	}
+
+	if cotl.GetExtensions() == nil {
+		t.Fatal("GetExtensions() = nil after registration")
+	}
+
+	buf, err := cotl.ToCBOR()
+	if err != nil {
+		t.Fatalf("ToCBOR with extensions failed: %v", err)
+	}
+
+	// As with github.com/veraison/corim, the extension struct must be
+	// registered on the destination before decoding so the decoder knows
+	// the concrete Go type to populate.
+	var repopulated ConciseTlTag
+	if err := repopulated.RegisterExtensions(extensions.NewMap().Add(ExtConciseTlTag, &testExt{})); err != nil {
+		t.Fatalf("RegisterExtensions failed: %v", err)
+	}
+
+	if err := repopulated.FromCBOR(buf); err != nil {
+		t.Fatalf("FromCBOR with registered extensions failed: %v", err)
+	}
+
+	ext, ok := repopulated.GetExtensions().(*testExt)
+	if !ok {
+		t.Fatalf("extension type = %T, want *testExt", repopulated.GetExtensions())
+	}
+
+	if ext.Foo != "bar" {
+		t.Errorf("extension field Foo = %q, want %q", ext.Foo, "bar")
+	}
+}
+
+func TestExtensionConstrainerRunsDuringValidation(t *testing.T) {
+	t.Parallel()
+
+	cotl := validCotl(t)
+	if err := cotl.RegisterExtensions(extensions.NewMap().Add(ExtConciseTlTag, &constrainingExt{MaxTags: 1})); err != nil {
+		t.Fatalf("RegisterExtensions failed: %v", err)
+	}
+
+	if err := cotl.Valid(); err == nil {
+		t.Fatal("constrainer limit not enforced during Valid()")
+	}
+
+	cotl.TagsList = cotl.TagsList[:1]
+	if err := cotl.Valid(); err != nil {
+		t.Fatalf("Valid() within constraint failed: %v", err)
+	}
+}
+
+func TestNoExtensionsRegisteredIsValid(t *testing.T) {
+	t.Parallel()
+
+	c := validCotl(t)
+	if err := c.validExtensions(); err != nil {
+		t.Fatalf("validExtensions() without registration failed: %v", err)
+	}
+}

--- a/cotl/extensions.go
+++ b/cotl/extensions.go
@@ -1,0 +1,62 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cotl
+
+import (
+	"fmt"
+
+	"github.com/veraison/corim/extensions"
+)
+
+// ExtConciseTlTag is the extension point on the top-level concise-tl-tag map.
+const ExtConciseTlTag extensions.Point = "ConciseTlTag"
+
+// RegisterExtensions registers a struct as a collection of extensions on this
+// CoTL. The struct is a pointer to a user-defined type whose exported fields
+// carry cbor/json key tags, following the mechanism used by
+// github.com/veraison/corim.
+//
+// An extension struct may additionally implement
+//
+//	ConstrainConciseTlTag(*ConciseTlTag) error
+//
+// in which case it participates in structural validation.
+func (o *ConciseTlTag) RegisterExtensions(exts extensions.Map) error {
+	for p, v := range exts {
+		switch p {
+		case ExtConciseTlTag:
+			o.Register(v)
+		default:
+			return fmt.Errorf("%w: %q", extensions.ErrUnexpectedPoint, p)
+		}
+	}
+
+	return nil
+}
+
+// GetExtensions returns the registered extension struct, or nil.
+func (o *ConciseTlTag) GetExtensions() extensions.IMapValue {
+	return o.IMapValue
+}
+
+// validExtensions invokes any registered constrainer.
+func (o *ConciseTlTag) validExtensions() error {
+	if !o.HaveExtensions() {
+		return nil
+	}
+
+	if ev, ok := o.IMapValue.(IConciseTlTagConstrainer); ok {
+		if err := ev.ConstrainConciseTlTag(o); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// IConciseTlTagConstrainer may be implemented by extension structs to
+// participate in structural validation of the enclosing CoTL.
+type IConciseTlTagConstrainer interface {
+	ConstrainConciseTlTag(*ConciseTlTag) error
+}

--- a/cotl/helpers_test.go
+++ b/cotl/helpers_test.go
@@ -1,0 +1,15 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cotl
+
+import (
+	cbor "github.com/fxamacker/cbor/v2"
+)
+
+func cborDecOptions() cbor.DecOptions {
+	return cbor.DecOptions{
+		IndefLength: cbor.IndefLengthAllowed,
+		TimeTag:     cbor.DecTagOptional,
+	}
+}

--- a/cotl/validate.go
+++ b/cotl/validate.go
@@ -1,0 +1,63 @@
+// Copyright 2026 Contributors to the Veraison project.
+// SPDX-License-Identifier: Apache-2.0
+
+package cotl
+
+import (
+	"errors"
+	"time"
+)
+
+// ErrEmptyTagsList is returned when a CoTL carries no tags: activation is
+// atomic per draft-ietf-rats-corim-11 Section 6, so an empty list can never
+// be meaningfully activated.
+var ErrEmptyTagsList = errors.New("empty tags-list: a CoTL must activate at least one tag")
+
+// Report is the outcome of appraising a CoTL at a point in time.
+type Report struct {
+	// Errors make the CoTL unusable for appraisal.
+	Errors []string
+	// Warnings flag conditions that do not invalidate the CoTL.
+	Warnings []string
+}
+
+// Valid returns true when the report carries no errors.
+func (r Report) Valid() bool {
+	return len(r.Errors) == 0
+}
+
+// ValidateAt appraises the CoTL at time now, mirroring the CoTL extraction
+// rules of draft-ietf-rats-corim-11 Section 8.2.3.4:
+//
+//   - CoTLs outside their validity window MUST be discarded
+//     (expired => error; not-yet-valid => warning).
+//   - The validity window is inclusive of both bounds (RFC 5280 convention).
+//   - Duplicate entries in tags-list are reported as warnings.
+func (o *ConciseTlTag) ValidateAt(now time.Time) Report {
+	var report Report
+
+	if o.TlValidity.NotBefore != nil {
+		if now.Before(*o.TlValidity.NotBefore) {
+			report.Warnings = append(report.Warnings,
+				"CoTL is not yet valid (not-before is in the future)")
+		}
+	}
+
+	if now.After(o.TlValidity.NotAfter) {
+		report.Errors = append(report.Errors,
+			"CoTL has expired (not-after is in the past)")
+	}
+
+	seen := make(map[string]bool, len(o.TagsList))
+	for _, t := range o.TagsList {
+		id := t.String()
+		if seen[id] {
+			report.Warnings = append(report.Warnings,
+				"duplicate tag-id in tags-list: "+id)
+			continue
+		}
+		seen[id] = true
+	}
+
+	return report
+}


### PR DESCRIPTION
Donate the veraison/cotl implementation upstream as corim/cotl, following the module's package-per-tag layout (comid, coserv, coev). Adapts the extension mechanism to the current extensions.Map/IMapValue API and wires the package into the Makefile and README package list.