### PR TITLE
fix(encoding): ensure input is well-formed before allocation

### DIFF
--- a/corim/signedcorim_test.go
+++ b/corim/signedcorim_test.go
@@ -256,7 +256,7 @@ func TestSignedCorim_FromCOSE_fail_corim_bad_cbor(t *testing.T) {
 	var actual SignedCorim
 	err := actual.FromCOSE(tv)
 
-	assert.EqualError(t, err, "failed CBOR decoding of unsigned CoRIM: unexpected EOF")
+	assert.EqualError(t, err, "failed CBOR decoding of unsigned CoRIM: malformed CBOR: unexpected EOF")
 }
 
 func TestSignedCorim_FromCOSE_fail_invalid_corim(t *testing.T) {

--- a/cotl/cotl.go
+++ b/cotl/cotl.go
@@ -204,12 +204,6 @@ func populateSafely(o *ConciseTlTag, content []byte) (err error) {
 		}
 	}()
 
-	// Gate on RFC 8949 well-formedness first: the corim encoding helpers do
-	// not defend against malformed map headers (they can loop indefinitely).
-	if err := dm.Wellformed(content); err != nil {
-		return fmt.Errorf("malformed CBOR: %w", err)
-	}
-
 	// Note: the corim encoding helpers (rather than plain Unmarshal) are
 	// deliberate here so that any extension structs previously passed to
 	// RegisterExtensions() are resolved through their embedded interface

--- a/encoding/cbor.go
+++ b/encoding/cbor.go
@@ -301,8 +301,8 @@ func (o *structFieldsCBOR) ToCBOR(em cbor.EncMode) ([]byte, error) {
 }
 
 func (o *structFieldsCBOR) FromCBOR(dm cbor.DecMode, data []byte) error {
-	if len(data) == 0 {
-		return errors.New("empty input")
+	if err := dm.Wellformed(data); err != nil {
+		return fmt.Errorf("malformed CBOR: %w", err)
 	}
 
 	header := data[0]

--- a/encoding/cbor_test.go
+++ b/encoding/cbor_test.go
@@ -279,17 +279,30 @@ func Test_structFieldsCBOR_CBOR_decode_indefinite(t *testing.T) {
 	assert.Equal(t, []int{0, 1, 2, 3, 4}, sfOut.Keys)
 }
 
+func Test_structFieldsCBOR_CBOR_decode_malformed(t *testing.T) {
+	data := []byte{
+		0xcb, 0xba, 0x5a, 0x47, 0x42, 0xe0, 0xa5, 0x4e,
+	}
+
+	dm, err := cbor.DecOptions{}.DecMode()
+	require.NoError(t, err)
+
+	sfOut := newStructFieldsCBOR()
+	err = sfOut.FromCBOR(dm, data)
+	assert.ErrorContains(t, err, "malformed CBOR")
+}
+
 func Test_structFieldsCBOR_CBOR_decode_negative(t *testing.T) {
 	dm, err := cbor.DecOptions{}.DecMode()
 	require.NoError(t, err)
 
 	sfOut := newStructFieldsCBOR()
 	err = sfOut.FromCBOR(dm, []byte{0xa1, 0xff, 0x00})
-	assert.EqualError(t, err, `map item 0: could not unmarshal key: cbor: unexpected "break" code`)
+	assert.EqualError(t, err, `malformed CBOR: cbor: unexpected "break" code`)
 	err = sfOut.FromCBOR(dm, []byte{0xbf, 0x00, 0x00})
-	assert.EqualError(t, err, `unexpected EOF`)
+	assert.EqualError(t, err, `malformed CBOR: unexpected EOF`)
 	err = sfOut.FromCBOR(dm, []byte{0xa1, 0x00, 0xff})
-	assert.EqualError(t, err, `map item 0: could not unmarshal value: cbor: unexpected "break" code`)
+	assert.EqualError(t, err, `malformed CBOR: cbor: unexpected "break" code`)
 
 	err = sfOut.FromCBOR(dm, []byte{0x00})
 	assert.EqualError(t, err, `expected map (CBOR Major Type 5), found Major Type 0`)


### PR DESCRIPTION
Perform `dm.Wellformed()` check on the input at the beginning of `structFieldsCBOR.FromCBOR()`. This prevents, among other things, random byte sequences from being interpreted as map headers with a large size and then waiting on the allocation.

Thanks to @larrydewey  for identifying the issue.